### PR TITLE
adds it to recipe using hash of title and publication date

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val etl = (project in file("etl"))
       libraryDependencies ++= Seq(
         "com.gu" %% "content-api-client" % "9.4",
         "org.jsoup" % "jsoup" % "1.9.2",
-        "org.typelevel" %% "cats-core" % "0.6.1"
+        "org.typelevel" %% "cats-core" % "0.6.1",
+        "commons-codec" % "commons-codec" % "1.10"
       ),
       cancelable in Global := true
   ))

--- a/etl/src/main/scala/etl/RecipeParsing.scala
+++ b/etl/src/main/scala/etl/RecipeParsing.scala
@@ -14,9 +14,7 @@ object RecipeParsing {
     val ingredients = guessIngredients(rawRecipe.body)
     val steps = guessSteps(rawRecipe.body)
 
-    // Do image-finding later, as we need to look through the whole article
     ParsedRecipe(
-      "id",
       rawRecipe.title,
       rawRecipe.body.toString,
       serves,

--- a/etl/src/main/scala/etl/models.scala
+++ b/etl/src/main/scala/etl/models.scala
@@ -9,7 +9,6 @@ case class RawRecipe(
 )
 
 case class ParsedRecipe(
-  id: String,
   title: String,
   body: String,
   serves: Option[Serves],


### PR DESCRIPTION
- Gives each recipe a hash of its title and publication date. 
- Removes comment about images as we are no longer going to try to match recipes to images.