### PR TITLE
writes curated recipe to db

### DIFF
--- a/common/src/main/resources/db/migration/V3__create_curated_recipe_table.sql
+++ b/common/src/main/resources/db/migration/V3__create_curated_recipe_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE curated_recipe(
+    id varchar(32) primary key,
+    title text not null,
+    body text not null,
+    serves jsonb null,
+    ingredients_lists jsonb not null,
+    article_id text not null,
+    credit text null,
+    publication_date timestamp with time zone not null,
+    status text not null,
+    times jsonb not null,
+    steps jsonb not null,
+    tags jsonb not null
+);
+

--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -2,6 +2,8 @@ package com.gu.recipeasy.models
 
 import java.time.OffsetDateTime
 import automagic._
+import io.circe._
+import cats.data.Xor
 import CuratedRecipeDB._
 
 case class CuratedRecipe(
@@ -60,6 +62,14 @@ object CookingUnit {
 
   def fromString(s: String): Option[CookingUnit] = {
     unitMap.get(s)
+  }
+
+  implicit val circeEncoder: Encoder[CookingUnit] = Encoder.encodeString.contramap[CookingUnit](_.abbreviation)
+  implicit val circeDecoder: Decoder[CookingUnit] = Decoder.decodeString.emap { str =>
+    fromString(str) match {
+      case Some(x) => Xor.right(x)
+      case None => Xor.left("Cannot decode unrecognised Cooking Unit")
+    }
   }
 
 }

--- a/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
@@ -22,6 +22,7 @@ sealed trait Status
 case object New extends Status
 case object Curated extends Status
 case object Impossible extends Status
+case object Pending extends Status
 
 case class IngredientsLists(lists: Seq[IngredientsList])
 

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -28,7 +28,10 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
   def curateRecipePage = Action { implicit request =>
     val newRecipe = db.getNewRecipe
     newRecipe match {
-      case Some(r) => Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(toForm(recipeTypeConversion.transformRecipe(r)))))
+      case Some(r) => {
+        db.setRecipeStatus(r.id, "Pending")
+        Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(toForm(recipeTypeConversion.transformRecipe(r)))))
+      }
       case None => NotFound
     }
   }
@@ -41,6 +44,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     }, { r =>
       val recipe = fromForm(r)
       db.insertCuratedRecipe(recipe)
+      db.setRecipeStatus(r.id, "Curated")
       Redirect(routes.Application.curateRecipePage)
     })
   }


### PR DESCRIPTION
- Creates a second DB table, called 'curated_recipe' to store `CuratedRecipe`s. 👯

- Converts submitted forms to a `CuratedRecipe` and then a `CuratedRecipeDB` (which has a simplified version of the tags).

- Writes the `CuratedRecipeDB` to 'curated_recipe' table.

- When a recipe is picked from recipe table to show in UI, its status is set to `Pending`.
- When the recipe is submitted to 'curated_recipe' table, it's corresponding entry in the 'recipe' table has status set to `Curated`. This is to prevent the same recipe being curated twice. 


