### PR TITLE
make tags multiselects

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -94,19 +94,10 @@ case class Tag(
 )
 
 object Tag {
-  val lowSugar = Tag("low sugar", "dietary")
-  val lowFat = Tag("low fat", "dietary")
-  val highFibre = Tag("high fibre", "dietary")
-  val nutFree = Tag("nut free", "dietary")
-  val glutenFree = Tag("gluten free", "dietary")
-  val dairyFree = Tag("dairy free", "dietary")
-  val eggFree = Tag("egg free", "dietary")
-  val vegetarian = Tag("vegetarian", "dietary")
-  val vegan = Tag("vegan", "dietary")
-
-  val cuisines = Seq("african", "british", "caribbean", "french", "greek", "indian", "irish", "italian", "japanese", "mexican", "nordic", "northAfrican", "portuguese", "southAmerican", "spanish", "thaiAndSouthEastAsian")
-  val mealTypes = Seq("barbecue", "breakfast", "budget", "canapes", "dessert", "dinner party", "drinks and cockails", "healthy eating", "lunch", "main course", "picnic", "sides", "snacks", "starters")
+  val cuisines = Seq("African", "British", "Caribbean", "French", "Greek", "Indian", "Irish", "Italian", "Japanese", "Mexican", "Nordic", "North African", "Portuguese", "South American", "Spanish", "Thai and South East Asian")
+  val mealTypes = Seq("Barbecue", "Breakfast", "Budget", "Canapes", "Dessert", "Dinner party", "Drinks and cockails", "Healthy eating", "Lunch", "Main course", "Picnic", "Sides", "Snacks", "Starters")
   val holidays = Seq("Baisakhi", "Christmas", "Diwali", "Easter", "Eid", "Halloween", "Hanukkah", "Passover", "Thanksgiving")
+  val dietary = Seq("Low sugar", "Low fat", "High fibre", "Nut free", "Gluten free", "Dairy free", "Egg free", "Vegetarian", "Vegan")
 }
 
 object CuratedRecipe {

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -108,17 +108,7 @@ object Application {
         "cuisine" -> seq(text),
         "mealType" -> seq(text),
         "holiday" -> seq(text),
-        "dietary" -> mapping(
-          "lowSugar" -> boolean,
-          "lowFat" -> boolean,
-          "highFibre" -> boolean,
-          "nutFree" -> boolean,
-          "glutenFree" -> boolean,
-          "dairyFree" -> boolean,
-          "eggFree" -> boolean,
-          "vegetarian" -> boolean,
-          "vegan" -> boolean
-        )(Dietary.apply)(Dietary.unapply)
+        "dietary" -> seq(text)
       )(FormTags.apply)(FormTags.unapply)
     )(CuratedRecipeForm.apply)(CuratedRecipeForm.unapply)
   )

--- a/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
+++ b/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
@@ -37,7 +37,7 @@ object CuratedRecipeForm {
     val cuisineTags = getTags(r.tags.cuisine, "cuisine")
     val mealTypeTags = getTags(r.tags.mealType, "mealType")
     val holidayTags = getTags(r.tags.holiday, "holiday")
-    val dietaryTags = getTags(r.tags.holiday, "dietary")
+    val dietaryTags = getTags(r.tags.dietary, "dietary")
 
     transform[CuratedRecipeForm, CuratedRecipe](
       r,

--- a/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
+++ b/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
@@ -37,7 +37,7 @@ object CuratedRecipeForm {
     val cuisineTags = getTags(r.tags.cuisine, "cuisine")
     val mealTypeTags = getTags(r.tags.mealType, "mealType")
     val holidayTags = getTags(r.tags.holiday, "holiday")
-    val dietaryTags = getDietaryTags(r.tags.dietary)
+    val dietaryTags = getTags(r.tags.holiday, "dietary")
 
     transform[CuratedRecipeForm, CuratedRecipe](
       r,

--- a/ui/app/com/gu/recipeasy/models/TagHelper.scala
+++ b/ui/app/com/gu/recipeasy/models/TagHelper.scala
@@ -8,7 +8,7 @@ object TagHelper {
     cuisine: Seq[String],
     mealType: Seq[String],
     holiday: Seq[String],
-    dietary: Dietary
+    dietary: Seq[String]
   )
 
   object FormTags {
@@ -17,35 +17,7 @@ object TagHelper {
         cuisine = tags.list.collect { case t if t.category == "cuisine" => t.name },
         mealType = tags.list.collect { case t if t.category == "mealType" => t.name },
         holiday = tags.list.collect { case t if t.category == "holiday" => t.name },
-        dietary = Dietary(tags)
-      )
-    }
-  }
-
-  case class Dietary(
-    lowSugar: Boolean,
-    lowFat: Boolean,
-    highFibre: Boolean,
-    nutFree: Boolean,
-    glutenFree: Boolean,
-    dairyFree: Boolean,
-    eggFree: Boolean,
-    vegetarian: Boolean,
-    vegan: Boolean
-  )
-
-  object Dietary {
-    def apply(tags: Tags): Dietary = {
-      Dietary(
-        lowSugar = tags.list.contains(Tag.lowSugar),
-        lowFat = tags.list.contains(Tag.lowFat),
-        highFibre = tags.list.contains(Tag.highFibre),
-        nutFree = tags.list.contains(Tag.nutFree),
-        glutenFree = tags.list.contains(Tag.glutenFree),
-        dairyFree = tags.list.contains(Tag.dairyFree),
-        eggFree = tags.list.contains(Tag.eggFree),
-        vegetarian = tags.list.contains(Tag.vegetarian),
-        vegan = tags.list.contains(Tag.vegan)
+        dietary = tags.list.collect { case t if t.category == "dietary" => t.name }
       )
     }
   }
@@ -54,21 +26,5 @@ object TagHelper {
     tags.collect { case s: String if (!s.isEmpty) => Tag(s, cat) }
   }
 
-  //TODO make nicer
-  def getDietaryTags(t: Dietary): Seq[Tag] = {
-    val tags = Map(
-      Tag.lowSugar -> t.lowSugar,
-      Tag.lowFat -> t.lowFat,
-      Tag.highFibre -> t.highFibre,
-      Tag.nutFree -> t.nutFree,
-      Tag.glutenFree -> t.glutenFree,
-      Tag.dairyFree -> t.dairyFree,
-      Tag.eggFree -> t.eggFree,
-      Tag.vegetarian -> t.vegetarian,
-      Tag.vegan -> t.vegan
-    )
-
-    tags.filter { _._2 }.keySet.toSeq
-  }
 }
 

--- a/ui/app/com/gu/recipeasy/views/bootstrap3/multiTag.scala.html
+++ b/ui/app/com/gu/recipeasy/views/bootstrap3/multiTag.scala.html
@@ -1,20 +1,11 @@
 @(field: Field, recipe: Form[models.CuratedRecipeForm])(o: Seq[String], fieldName: String, label: (Symbol,Any))(implicit fc: b3.B3FieldConstructor, messages: Messages)
 @tags = @{field.indexes.map(i => field.apply(s"[$i]"))}
-@fieldOptions = @{ ("", "") +: o.map(x => (x, x)).toSeq }
-@emptyField = @{fieldName + "[0]"}
+@fieldOptions = @{o.map(x => (x, x)).toSeq }
 
 @b3.multifield(tags:_*)(Seq(label), Nil) { implicit cfc =>
-  <div class="tags" @toHtmlArgs(bs.Args.inner(Seq(label)).toMap)>
-      @if(tags.isEmpty){
-          <div class="flex tag">
-              @b3.select(recipe("tags")(emptyField), options=fieldOptions)
-          </div>
-          } else {
-              @tags.zipWithIndex.map { case (o, i) =>
-              <div class="flex tag">
-                  @b3.select(o, options=fieldOptions)
-              </div>
-              }
-          }
-      </div>
+    <div class="tags" @toHtmlArgs(bs.Args.inner(Seq(label)).toMap)>
+        <div class="flex tags">
+            @b3.select(field, options=fieldOptions, 'multiple -> true, 'class -> "selectpicker")
+        </div>
+    </div>
 }

--- a/ui/app/com/gu/recipeasy/views/layout.scala.html
+++ b/ui/app/com/gu/recipeasy/views/layout.scala.html
@@ -5,8 +5,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Recipeasy</title>
-    <link rel="stylesheet" media="screen" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link href="@routes.Assets.versioned("stylesheets/main.css")" type="text/css" rel="stylesheet"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.11.2/css/bootstrap-select.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 </head>
 <body>

--- a/ui/app/com/gu/recipeasy/views/recipeLayout.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipeLayout.scala.html
@@ -1,7 +1,6 @@
 @(curatedRecipeForm: Form[models.CuratedRecipeForm])(implicit messages: play.api.i18n.Messages)
 @implicitFC = @{ b3.vertical.fieldConstructor }
 @import com.gu.recipeasy.models.Tag
-@diet = @{ curatedRecipeForm("tags")("dietary") }
 
 @layout("Recipeasy"){
     @b3.form(routes.Application.curateRecipe) {
@@ -23,27 +22,18 @@
                 @bootstrap3.multiStep(
                     curatedRecipeForm("steps"), curatedRecipeForm
                     )('_label -> "Method steps")
-                @bootstrap3.multiCheckbox(
-                    (diet("lowSugar"), Seq('_text -> "low sugar")),
-                    (diet("lowFat"), Seq('_text -> "low fat")),
-                    (diet("highFibre"), Seq('_text -> "high fibre")),
-                    (diet("nutFree"), Seq('_text -> "nut free")),
-                    (diet("glutenFree"), Seq('_text -> "gluten free")),
-                    (diet("dairyFree"), Seq('_text -> "dairy free")),
-                    (diet("eggFree"), Seq('_text -> "egg free")),
-                    (diet("vegetarian"), Seq('_text -> "vegetarian")),
-                    (diet("vegan"), Seq('_text -> "vegan"))
-                )('_label -> "Diets", 'class -> "multi-checkbox-list inline")
-                @bootstrap3.multiTag(curatedRecipeForm("tags")("cuisine"), curatedRecipeForm)(Tag.cuisines, "cuisine", '_label -> "Cuisine type")
-                @bootstrap3.multiTag(curatedRecipeForm("tags")("mealType"), curatedRecipeForm)(Tag.mealTypes, "mealType", '_label -> "Meal type")
-                @bootstrap3.multiTag(curatedRecipeForm("tags")("holiday"), curatedRecipeForm)(Tag.holidays, "holiday", '_label -> "Holiday")
+                @bootstrap3.multiTag(curatedRecipeForm("tags")("cuisine"), curatedRecipeForm)(Tag.cuisines, "cuisine", '_label -> "Cuisines")
+                @bootstrap3.multiTag(curatedRecipeForm("tags")("mealType"), curatedRecipeForm)(Tag.mealTypes, "mealType", '_label -> "Meal types")
+                @bootstrap3.multiTag(curatedRecipeForm("tags")("holiday"), curatedRecipeForm)(Tag.holidays, "holiday", '_label -> "Holidays")
+                @bootstrap3.multiTag(curatedRecipeForm("tags")("dietary"), curatedRecipeForm)(Tag.dietary, "dietary", '_label -> "Dietary")
                 @b3.text( curatedRecipeForm("status"), '_label -> "Recipe status", 'readonly -> "readonly")
                 @b3.submit('class -> "btn btn-primary btn-block") { Submit Recipe }
             </div>
         </div>
     }
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<script src="@routes.Assets.versioned("javascript/editForm.js")" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.11.2/js/bootstrap-select.min.js"></script>
+    <script src="@routes.Assets.versioned("javascript/editForm.js")" type="text/javascript"></script>
+
 }
 


### PR DESCRIPTION
Adds support for multiple tags - for all the fusion recipes out there. 🙌

- Uses the same multi-select form template for all tags.
- Removes the specific `Dietary` tag code (which converted tags to booleans to create a checklist). 
- Uses multi-select plugin for much UI win.

![tagstagstags](https://cloud.githubusercontent.com/assets/8484757/18674973/cf077bda-7f48-11e6-8739-e16a369267c1.gif)

