### PR TITLE
Remove unnecessary form fields

### DIFF
--- a/common/src/main/resources/db/migration/V3__create_curated_recipe_table.sql
+++ b/common/src/main/resources/db/migration/V3__create_curated_recipe_table.sql
@@ -1,15 +1,12 @@
 CREATE TABLE curated_recipe(
-    id varchar(32) primary key,
+    -- NB id not consistent with recipe table which uses varchar(32) :( --
+    id serial primary key,
+    recipe_id varchar(32) REFERENCES recipe (id),
     title text not null,
-    body text not null,
     serves jsonb null,
     ingredients_lists jsonb not null,
-    article_id text not null,
     credit text null,
-    publication_date timestamp with time zone not null,
-    status text not null,
     times jsonb not null,
     steps jsonb not null,
     tags jsonb not null
 );
-

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -90,7 +90,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     val crDB: CuratedRecipeDB = CuratedRecipe.toDBModel(cr)
     try {
       val action = quote {
-        table.insert(lift(crDB))
+        table.insert(lift(crDB)).returning(_.id)
       }
       ctx.run(action)
     } catch {

--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipeDB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipeDB.scala
@@ -5,15 +5,12 @@ package com.gu.recipeasy.models
 import java.time.OffsetDateTime
 
 case class CuratedRecipeDB(
-  id: String,
+  id: Long,
+  recipeId: String,
   title: String,
-  body: String,
   serves: Option[Serves],
   ingredientsLists: DetailedIngredientsLists,
-  articleId: String,
   credit: Option[String],
-  publicationDate: OffsetDateTime,
-  status: Status,
   times: TimesInMins,
   steps: Steps,
   tags: TagNames

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -32,7 +32,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
         val recipeId = r.id
         val curatedRecipe = CuratedRecipe.fromRecipe(r)
         val curatedRecipeForm = CuratedRecipeForm.toForm(curatedRecipe)
-        db.setRecipeStatus(articleId, "Pending")
+        db.setRecipeStatus(recipeId, "Pending")
         Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(curatedRecipeForm), recipeId))
       }
       case None => NotFound

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -29,45 +29,27 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     val newRecipe = db.getNewRecipe
     newRecipe match {
       case Some(r) => {
-        db.setRecipeStatus(r.id, "Pending")
-        Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(toForm(recipeTypeConversion.transformRecipe(r)))))
+        val articleId = r.id
+        val curatedRecipe = CuratedRecipe.fromRecipe(r)
+        val curatedRecipeForm = CuratedRecipeForm.toForm(curatedRecipe)
+        db.setRecipeStatus(articleId, "Pending")
+        Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(curatedRecipeForm), articleId))
       }
       case None => NotFound
     }
   }
 
-  def curateRecipe = Action { implicit request =>
-    //create curated recipe to store in db
+  def curateRecipe(recipeId: String) = Action { implicit request =>
     val formValidationResult = Application.createCuratedRecipeForm.bindFromRequest
     formValidationResult.fold({ formWithErrors =>
-      BadRequest(views.html.recipeLayout(formWithErrors))
+      BadRequest(views.html.recipeLayout(formWithErrors, recipeId))
     }, { r =>
-      val recipe = fromForm(r)
-      db.insertCuratedRecipe(recipe)
-      db.setRecipeStatus(r.id, "Curated")
+      val halfBakedRecipe = fromForm(r)
+      val recipeWithId = halfBakedRecipe.copy(recipeId = recipeId, id = 0L)
+      db.insertCuratedRecipe(recipeWithId)
+      db.setRecipeStatus(recipeId, "Curated")
       Redirect(routes.Application.curateRecipePage)
     })
-  }
-
-}
-
-object recipeTypeConversion {
-  def transformRecipe(r: Recipe): CuratedRecipe = {
-    transform[Recipe, CuratedRecipe](
-      r,
-      "times" -> TimesInMins(None, None),
-      "tags" -> Tags(List.empty),
-      "ingredientsLists" -> rawToDetailedIngredientsLists(r.ingredientsLists)
-    )
-  }
-
-  def rawToDetailedIngredientsLists(ingredients: IngredientsLists): DetailedIngredientsLists = {
-    new DetailedIngredientsLists(lists =
-      ingredients.lists.map(r => new DetailedIngredientsList(r.title, rawToDetailedIngredients(r.ingredients))))
-  }
-
-  def rawToDetailedIngredients(ingredients: Seq[String]): Seq[DetailedIngredient] = {
-    ingredients.map(i => new DetailedIngredient(None, None, "", None, i))
   }
 
 }
@@ -78,9 +60,7 @@ object Application {
 
   val createCuratedRecipeForm: Form[CuratedRecipeForm] = Form(
     mapping(
-      "id" -> of[String],
       "title" -> nonEmptyText(maxLength = 200),
-      "body" -> of[String],
       "serves" -> optional(mapping(
         "from" -> number(min = 1),
         "to" -> number(min = 1)
@@ -95,10 +75,7 @@ object Application {
           "raw" -> text
         )(DetailedIngredient.apply)(DetailedIngredient.unapply))
       )(DetailedIngredientsList.apply)(DetailedIngredientsList.unapply)),
-      "articleId" -> of[String],
       "credit" -> optional(text(maxLength = 200)),
-      "publicationDate" -> of[String],
-      "status" -> of[String],
       "times" -> mapping(
         "preparation" -> optional(of[Double]),
         "cooking" -> optional(of[Double])

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -29,11 +29,11 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     val newRecipe = db.getNewRecipe
     newRecipe match {
       case Some(r) => {
-        val articleId = r.id
+        val recipeId = r.id
         val curatedRecipe = CuratedRecipe.fromRecipe(r)
         val curatedRecipeForm = CuratedRecipeForm.toForm(curatedRecipe)
         db.setRecipeStatus(articleId, "Pending")
-        Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(curatedRecipeForm), articleId))
+        Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(curatedRecipeForm), recipeId))
       }
       case None => NotFound
     }

--- a/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
+++ b/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
@@ -6,15 +6,10 @@ import java.time.OffsetDateTime
 import automagic._
 
 case class CuratedRecipeForm(
-  id: String,
   title: String,
-  body: String,
   serves: Option[Serves],
   ingredientsLists: Seq[DetailedIngredientsList],
-  articleId: String,
   credit: Option[String],
-  publicationDate: String,
-  status: String,
   times: TimesInMins,
   steps: Seq[String],
   tags: FormTags
@@ -26,8 +21,6 @@ object CuratedRecipeForm {
     transform[CuratedRecipe, CuratedRecipeForm](
       r,
       "ingredientsLists" -> r.ingredientsLists.lists,
-      "publicationDate" -> r.publicationDate.toString,
-      "status" -> r.status.toString,
       "steps" -> r.steps.steps,
       "tags" -> FormTags(r.tags)
     )
@@ -41,9 +34,10 @@ object CuratedRecipeForm {
 
     transform[CuratedRecipeForm, CuratedRecipe](
       r,
+      //these are set in the controller
+      "id" -> 0L,
+      "recipeId" -> "",
       "ingredientsLists" -> DetailedIngredientsLists(r.ingredientsLists),
-      "publicationDate" -> OffsetDateTime.parse(r.publicationDate),
-      "status" -> Curated,
       "steps" -> Steps(r.steps),
       "tags" -> Tags(cuisineTags ++ mealTypeTags ++ holidayTags ++ dietaryTags)
     )

--- a/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredient.scala.html
+++ b/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredient.scala.html
@@ -7,7 +7,7 @@
   <div @toHtmlArgs(bs.Args.inner(globalArgs).toMap) class="ingredients">
     @if(ingredients.isEmpty){
         <div class="flex ingredient">
-            @b3.textarea(field("ingredients")("raw"), 'class -> "flex__child-big ingredient__detail ingredient__detail__parsed-ingredient", 'readonly -> "readonly")
+            @b3.textarea(field("ingredients")("raw"), 'class -> "flex__child-big ingredient__detail ingredient__detail__parsed-ingredient")
             @b3.number(field("ingredients")("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity flex__child-small")
             @b3.select(field("ingredients")("unit"), options=units, 'class -> "ingredient__detail ingredient__detail__unit flex__child-small", '_label -> "unit")
             @b3.text(field("ingredients")("item"), 'class -> "ingredient__detail ingredient__detail__item", 'placeholder -> "ingredient", 'required -> true)

--- a/ui/app/com/gu/recipeasy/views/recipeLayout.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipeLayout.scala.html
@@ -1,15 +1,11 @@
-@(curatedRecipeForm: Form[models.CuratedRecipeForm])(implicit messages: play.api.i18n.Messages)
+@(curatedRecipeForm: Form[models.CuratedRecipeForm], recipeId: String)(implicit messages: play.api.i18n.Messages)
 @implicitFC = @{ b3.vertical.fieldConstructor }
 @import com.gu.recipeasy.models.Tag
 
 @layout("Recipeasy"){
-    @b3.form(routes.Application.curateRecipe) {
+    @b3.form(routes.Application.curateRecipe(recipeId)) {
         <div class="row">
             <div class="col-md-10 col-md-offset-1 column">
-                @b3.hidden( "articleId", curatedRecipeForm("articleId").value)
-                @b3.hidden( "id", curatedRecipeForm("id").value)
-                @b3.hidden( "body", curatedRecipeForm("body").value)
-                @b3.hidden( "publicationDate", curatedRecipeForm("publicationDate").value)
                 @b3.text( curatedRecipeForm("title"), '_label -> "Recipe title")
                 <div class="flex field__serves">
                     @b3.number( curatedRecipeForm("serves")("from"), '_label -> "Serves from")
@@ -26,7 +22,6 @@
                 @bootstrap3.multiTag(curatedRecipeForm("tags")("mealType"), curatedRecipeForm)(Tag.mealTypes, "mealType", '_label -> "Meal types")
                 @bootstrap3.multiTag(curatedRecipeForm("tags")("holiday"), curatedRecipeForm)(Tag.holidays, "holiday", '_label -> "Holidays")
                 @bootstrap3.multiTag(curatedRecipeForm("tags")("dietary"), curatedRecipeForm)(Tag.dietary, "dietary", '_label -> "Dietary")
-                @b3.text( curatedRecipeForm("status"), '_label -> "Recipe status", 'readonly -> "readonly")
                 @b3.submit('class -> "btn btn-primary btn-block") { Submit Recipe }
             </div>
         </div>

--- a/ui/conf/routes
+++ b/ui/conf/routes
@@ -5,7 +5,7 @@ GET        /healthcheck                                                   contro
 
 GET        /                                                              controllers.Application.index
 GET        /recipe/curate                                                 controllers.Application.curateRecipePage
-POST       /recipe/curate                                                 controllers.Application.curateRecipe
+POST       /recipe/curate/:recipeId                                       controllers.Application.curateRecipe(recipeId)
 
 # Auth
 GET        /login                                                         controllers.Login.login

--- a/ui/test/com/gu/recipeasy/ApplicationSpec.scala
+++ b/ui/test/com/gu/recipeasy/ApplicationSpec.scala
@@ -35,21 +35,18 @@ class recipeConversion extends FlatSpec with Matchers {
     )
 
     val curatedRecipe = new CuratedRecipe(
-      id = "abc",
+      id = 0L,
+      recipeId = "abc",
       title = "Everyday breakfast",
-      body = "<p>breakfast</p>",
       serves = None,
       ingredientsLists = detailedBreakfast,
-      articleId = "breakfast",
       credit = None,
-      publicationDate = time,
-      status = New,
       times = TimesInMins(None, None),
       steps = Steps(List.empty),
       tags = Tags(List.empty)
     )
 
-    recipeTypeConversion.transformRecipe(recipe) should be(curatedRecipe)
+    CuratedRecipe.fromRecipe(recipe) should be(curatedRecipe)
   }
 }
 


### PR DESCRIPTION
Trimming the fat! 🏋

- Removes un-editable fields from `CuratedRecipeForm`, `CuratedRecipe`.
- Passes `recipeId` in as a url parameter to keep link between form and original recipe. 
- Moves transformation methods out of application into relevant companion object.

- NB DB migration v3 has been edited. This is NOT a problem because the older version has not been run in PROD. 💃

