### PR TITLE
adding original recipe to form

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -85,6 +85,21 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     ctx.run(a)
   }
 
+  def getBody(recipeId: String) = {
+    val body = ctx.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId)).map(_.body)).headOption
+    body match {
+      case Some(b) => b
+      case None => ""
+    }
+  }
+
+  def getArticleId(recipeId: String) = {
+    val articleId = ctx.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId)).map(_.articleId)).headOption
+    articleId match {
+      case Some(b) => b
+      case None => ""
+    }
+  }
   def insertCuratedRecipe(cr: CuratedRecipe): Unit = {
     val table = quote(query[CuratedRecipeDB].schema(_.entity("curated_recipe")))
     val crDB: CuratedRecipeDB = CuratedRecipe.toDBModel(cr)

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -42,29 +42,19 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
   }
 
   def curateRecipe(recipeId: String) = Action { implicit request =>
-    val a = request.body.asFormUrlEncoded.get("action").headOption
-    println("action", a)
-    a match {
-      case Some("submit") => {
-        val formValidationResult = Application.createCuratedRecipeForm.bindFromRequest
-        formValidationResult.fold({ formWithErrors =>
-          val body = db.getBody(recipeId)
-          val articleId = db.getArticleId(recipeId)
-          BadRequest(views.html.recipeLayout(formWithErrors, recipeId, body, articleId))
-        }, { r =>
-          val halfBakedRecipe = fromForm(r)
-          val recipeWithId = halfBakedRecipe.copy(recipeId = recipeId, id = 0L)
-          db.insertCuratedRecipe(recipeWithId)
-          db.setRecipeStatus(recipeId, "Curated")
-          Redirect(routes.Application.curateRecipePage)
-        })
-      }
-      case _ => {
+    val formValidationResult = Application.createCuratedRecipeForm.bindFromRequest
+    formValidationResult.fold({ formWithErrors =>
+      val body = db.getBody(recipeId)
+      val articleId = db.getArticleId(recipeId)
+      BadRequest(views.html.recipeLayout(formWithErrors, recipeId, body, articleId))
+      }, { r =>
+        val halfBakedRecipe = fromForm(r)
+        val recipeWithId = halfBakedRecipe.copy(recipeId = recipeId, id = 0L)
+        db.insertCuratedRecipe(recipeWithId)
+        db.setRecipeStatus(recipeId, "Curated")
         Redirect(routes.Application.curateRecipePage)
-      }
-    }
+      })
   }
-
 }
 
 object Application {

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -30,26 +30,39 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     newRecipe match {
       case Some(r) => {
         val recipeId = r.id
+        val body = r.body
+        val articleId = r.articleId
         val curatedRecipe = CuratedRecipe.fromRecipe(r)
         val curatedRecipeForm = CuratedRecipeForm.toForm(curatedRecipe)
         db.setRecipeStatus(recipeId, "Pending")
-        Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(curatedRecipeForm), recipeId))
+        Ok(views.html.recipeLayout(createCuratedRecipeForm.fill(curatedRecipeForm), recipeId, body, articleId))
       }
       case None => NotFound
     }
   }
 
   def curateRecipe(recipeId: String) = Action { implicit request =>
-    val formValidationResult = Application.createCuratedRecipeForm.bindFromRequest
-    formValidationResult.fold({ formWithErrors =>
-      BadRequest(views.html.recipeLayout(formWithErrors, recipeId))
-    }, { r =>
-      val halfBakedRecipe = fromForm(r)
-      val recipeWithId = halfBakedRecipe.copy(recipeId = recipeId, id = 0L)
-      db.insertCuratedRecipe(recipeWithId)
-      db.setRecipeStatus(recipeId, "Curated")
-      Redirect(routes.Application.curateRecipePage)
-    })
+    val a = request.body.asFormUrlEncoded.get("action").headOption
+    println("action", a)
+    a match {
+      case Some("submit") => {
+        val formValidationResult = Application.createCuratedRecipeForm.bindFromRequest
+        formValidationResult.fold({ formWithErrors =>
+          val body = db.getBody(recipeId)
+          val articleId = db.getArticleId(recipeId)
+          BadRequest(views.html.recipeLayout(formWithErrors, recipeId, body, articleId))
+        }, { r =>
+          val halfBakedRecipe = fromForm(r)
+          val recipeWithId = halfBakedRecipe.copy(recipeId = recipeId, id = 0L)
+          db.insertCuratedRecipe(recipeWithId)
+          db.setRecipeStatus(recipeId, "Curated")
+          Redirect(routes.Application.curateRecipePage)
+        })
+      }
+      case _ => {
+        Redirect(routes.Application.curateRecipePage)
+      }
+    }
   }
 
 }

--- a/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredient.scala.html
+++ b/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredient.scala.html
@@ -8,7 +8,7 @@
     @if(ingredients.isEmpty){
         <div class="flex ingredient">
             @b3.textarea(field("ingredients")("raw"), 'class -> "flex__child-big ingredient__detail ingredient__detail__parsed-ingredient")
-            @b3.number(field("ingredients")("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity flex__child-small")
+            @b3.number(field("ingredients")("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity flex__child-small", 'step -> 0.25)
             @b3.select(field("ingredients")("unit"), options=units, 'class -> "ingredient__detail ingredient__detail__unit flex__child-small", '_label -> "unit")
             @b3.text(field("ingredients")("item"), 'class -> "ingredient__detail ingredient__detail__item", 'placeholder -> "ingredient", 'required -> true)
             @b3.text(field("ingredients")("comment"), 'class -> "ingredient__detail ingredient__detail__comment", 'placeholder -> "comment")
@@ -19,7 +19,7 @@
         @ingredients.zipWithIndex.map { case (i, index) =>
             <div class="flex ingredient">
                 @b3.textarea(i("raw"), 'class -> "flex__child-big ingredient__detail ingredient__detail__parsed-ingredient")
-                @b3.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity flex__child-small")
+                @b3.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity flex__child-small", 'step -> 0.25)
                 @b3.select(i("unit"), options=units, 'class -> "ingredient__detail ingredient__detail__unit flex__child-small", '_label -> "unit")
                 @b3.text(i("item"), 'class -> "ingredient__detail ingredient__detail__item", 'placeholder -> "ingredient", 'required -> true)
                 @b3.text(i("comment"), 'class -> "ingredient__detail ingredient__detail__comment", 'placeholder -> "comment")

--- a/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredient.scala.html
+++ b/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredient.scala.html
@@ -18,7 +18,7 @@
     } else {
         @ingredients.zipWithIndex.map { case (i, index) =>
             <div class="flex ingredient">
-                @b3.textarea(i("raw"), 'class -> "flex__child-big ingredient__detail ingredient__detail__parsed-ingredient", 'readonly -> "readonly")
+                @b3.textarea(i("raw"), 'class -> "flex__child-big ingredient__detail ingredient__detail__parsed-ingredient")
                 @b3.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity flex__child-small")
                 @b3.select(i("unit"), options=units, 'class -> "ingredient__detail ingredient__detail__unit flex__child-small", '_label -> "unit")
                 @b3.text(i("item"), 'class -> "ingredient__detail ingredient__detail__item", 'placeholder -> "ingredient", 'required -> true)

--- a/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredientsList.scala.html
+++ b/ui/app/com/gu/recipeasy/views/bootstrap3/multiIngredientsList.scala.html
@@ -5,18 +5,38 @@
     <div @toHtmlArgs(bs.Args.inner(globalArgs).toMap)>
         @if(ingredientsLists.isEmpty){
             <div class="ingredients-list">
-                @b3.button('class -> "btn btn-default btn-sm button-add ingredients-list__button-add") { <span class="glyphicon glyphicon-plus"></span> }
-                @b3.button('class -> "btn btn-default btn-sm button-remove ingredients-list__button-remove"){ <span class="glyphicon glyphicon-minus"></span> }
-                @b3.text(field("title"), 'placeholder -> "Optional ingredient list title")
+                <div class="flex">
+                    @b3.text(field("title"), 'placeholder -> "Optional ingredient list title, e.g. biscuit base")
+                    @b3.button('class -> "btn btn-default btn-sm button-add ingredients-list__button-add") { <span class="glyphicon glyphicon-plus"></span> }
+                    @b3.button('class -> "btn btn-default btn-sm button-remove ingredients-list__button-remove"){ <span class="glyphicon glyphicon-minus"></span> }
+                </div>
+                <div class="flex ingredient-title">
+                    <h6>Original ingredient</h6>
+                    <h6>Quantity</h6>
+                    <h6>Unit</h6>
+                    <h6>Ingredient</h6>
+                    <h6>Comment</h6>
+                    <h6>Add another ingredient</h6>
+                </div>
                 @multiIngredient(field("ingredientsLists")("ingredients"))()
                 <hr>
             </div>
         } else {
             @ingredientsLists.zipWithIndex.map { case (list, i) =>
                 <div class="ingredients-list">
-                    @b3.button('class -> "btn btn-default btn-sm button-add ingredients-list__button-add") { <span class="glyphicon glyphicon-plus"></span> }
-                    @b3.button('class -> "btn btn-default btn-sm button-remove ingredients-list__button-remove"){ <span class="glyphicon glyphicon-minus"></span> }
-                    @b3.text(list("title"), 'placeholder -> "Optional ingredient list title")
+                    <div class="flex">
+                        @b3.text(list("title"), 'placeholder -> "Optional ingredient list title, e.g. biscuit base")
+                        @b3.button('class -> "btn btn-default btn-sm button-add ingredients-list__button-add") { <span class="glyphicon glyphicon-plus"></span> }
+                        @b3.button('class -> "btn btn-default btn-sm button-remove ingredients-list__button-remove"){ <span class="glyphicon glyphicon-minus"></span> }
+                    </div>
+                    <div class="flex ingredient-title">
+                        <h6>Original ingredient</h6>
+                        <h6>Quantity</h6>
+                        <h6>Unit</h6>
+                        <h6>Ingredient</h6>
+                        <h6>Comment</h6>
+                        <h6>Add another ingredient</h6>
+                    </div>
                     @multiIngredient(list("ingredients"))()
                     <hr>
                 </div>

--- a/ui/app/com/gu/recipeasy/views/recipeLayout.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipeLayout.scala.html
@@ -1,11 +1,18 @@
-@(curatedRecipeForm: Form[models.CuratedRecipeForm], recipeId: String)(implicit messages: play.api.i18n.Messages)
+@(curatedRecipeForm: Form[models.CuratedRecipeForm], recipeId: String, body: String, articleId: String)(implicit messages: play.api.i18n.Messages)
 @implicitFC = @{ b3.vertical.fieldConstructor }
 @import com.gu.recipeasy.models.Tag
+@link = @{ "https://www.gu.com/" + articleId }
 
 @layout("Recipeasy"){
+<div class="recipe">
+    <div class="recipe__original">
+        <h2>Please fill in the form with this recipe</h2>
+        <p>If some details are missing, <a href=@link target="_blank">click here for link to original article</a></p>
+        <hr>
+        @Html(body)
+    </div>
+    <div class="recipe__form">
     @b3.form(routes.Application.curateRecipe(recipeId)) {
-        <div class="row">
-            <div class="col-md-10 col-md-offset-1 column">
                 @b3.text( curatedRecipeForm("title"), '_label -> "Recipe title")
                 <div class="flex field__serves">
                     @b3.number( curatedRecipeForm("serves")("from"), '_label -> "Serves from")
@@ -23,8 +30,9 @@
                 @bootstrap3.multiTag(curatedRecipeForm("tags")("holiday"), curatedRecipeForm)(Tag.holidays, "holiday", '_label -> "Holidays")
                 @bootstrap3.multiTag(curatedRecipeForm("tags")("dietary"), curatedRecipeForm)(Tag.dietary, "dietary", '_label -> "Dietary")
                 @b3.submit('class -> "btn btn-primary btn-block") { Submit Recipe }
+                <a href="javascript:history.go(0)" class="btn btn-danger btn-block">Skip this recipe :(</a>
             </div>
-        </div>
+</div>
     }
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.11.2/js/bootstrap-select.min.js"></script>

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -1,15 +1,43 @@
+button {
+    height: 36px;
+}
+
 .flex {
    display: flex;
 }
 
+.recipe__original, .recipe__form {
+    padding: 10px
+}
+
+.recipe__original {
+    width: 40%; /*ensure width + recipe__form width = 100%*/
+    border-right: 1px solid #d3d3d3;
+}
+
+.recipe__form {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    overflow: scroll;
+    width: 60%; /*ensure width + recipe__original width = 100%*/
+    left: 40%;
+}
+
+
 .flex__child-big {
-    flex-basis: 50%;
+    flex-basis: 100%;
 }
 
 .flex__child-small {
     flex-basis: 20%;
 }
 
+.ingredient-title {
+    justify-content: space-between;
+}
+
 .ingredient__detail {
     margin: 2px 2px;
 }
+

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -11,7 +11,7 @@ button {
 }
 
 .recipe__original {
-    width: 40%; /*ensure width + recipe__form width = 100%*/
+    width: 40%; /*ensure this + recipe__form width = 100%*/
     border-right: 1px solid #d3d3d3;
 }
 
@@ -20,7 +20,7 @@ button {
     top: 0;
     bottom: 0;
     overflow: scroll;
-    width: 60%; /*ensure width + recipe__original width = 100%*/
+    width: 60%; /*ensure this + recipe__original width = 100%*/
     left: 40%;
 }
 
@@ -30,7 +30,7 @@ button {
 }
 
 .flex__child-small {
-    flex-basis: 20%;
+    flex-basis: 22%; /*the minimum value that still displays unit text correctly*/
 }
 
 .ingredient-title {
@@ -38,6 +38,10 @@ button {
 }
 
 .ingredient__detail {
-    margin: 2px 2px;
+    margin: 1px;
+}
+
+.form-control {
+    padding: 5px;
 }
 


### PR DESCRIPTION
- Looks up `articleId` and `body` in `recipe` table (using `recipeId`) to surface on UI
- Adds recipe parsed by ETL to the page
- Adds link to original article
- Adds link (styled as a button) to skip recipe
- Adds title to ingredient, not styled very well...

![recipeasy](https://cloud.githubusercontent.com/assets/8484757/18713300/b7b003b4-8009-11e6-9d64-fe08977df4a7.gif)

