### PR TITLE
adds scheduler to clean db

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,8 @@ lazy val ui = (project in file("ui"))
       "com.gu" %% "play-googleauth" % "0.5.0",
       "com.gu" %% "configuration-magic-play2-4" % "1.2.0",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
-      "com.adrianhurt" %% "play-bootstrap" % "1.1-P25-B3"
+      "com.adrianhurt" %% "play-bootstrap" % "1.1-P25-B3",
+      "org.quartz-scheduler" % "quartz" % "2.2.3"
     ),
     routesGenerator := InjectedRoutesGenerator,
     riffRaffPackageName := "recipeasy",

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -74,18 +74,18 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     }
   }
 
-  def getNewRecipe: Option[Recipe] = {
+  def getNewRecipe(): Option[Recipe] = {
     ctx.run(quote(query[Recipe]).filter(r => r.status == "New").sortBy(r => r.publicationDate)(Ord.desc).take(1)).headOption
   }
 
-  def setRecipeStatus(recipeId: String, status: String) = {
+  def setRecipeStatus(recipeId: String, status: String): Unit = {
     val a = quote {
       query[Recipe].filter(r => r.id == lift(recipeId)).update(_.status -> lift(status))
     }
     ctx.run(a)
   }
 
-  def getRecipe(recipeId: String) = {
+  def getRecipe(recipeId: String): Unit = {
     ctx.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId))).headOption
   }
 
@@ -102,7 +102,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     }
   }
 
-  def resetStatus = {
+  def resetStatus(): Unit = {
     val a = quote(query[Recipe].filter(_.status == "Pending").update(_.status -> "New"))
     ctx.run(a)
   }

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -85,7 +85,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     ctx.run(a)
   }
 
-  def getRecipe(recipeId: String): Unit = {
+  def getRecipe(recipeId: String): Option[Recipe] = {
     ctx.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId))).headOption
   }
 

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -101,4 +101,9 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
       case e: java.sql.BatchUpdateException => throw e.getNextException
     }
   }
+
+  def resetStatus = {
+    val a = quote(query[Recipe].filter(_.status == "Pending").update(_.status -> "New"))
+    ctx.run(a)
+  }
 }

--- a/ui/app/com/gu/recipeasy/AppComponents.scala
+++ b/ui/app/com/gu/recipeasy/AppComponents.scala
@@ -11,7 +11,7 @@ import io.getquill._
 import com.gu.recipeasy.db.DB
 
 import scala.concurrent.Future
-import schedule.DBCleaner
+import schedule.DBHouseKeepingScheduler
 
 class AppComponents(context: Context)
     extends BuiltInComponentsFromContext(context)
@@ -30,7 +30,7 @@ class AppComponents(context: Context)
   applicationLifecycle.addStopHook(() => Future.successful(dbContext.close()))
   val db = new DB(dbContext)
   val messagesApi: MessagesApi = new DefaultMessagesApi(environment, configuration, new DefaultLangs(configuration))
-  val dbScheduler = new DBCleaner(db)
+  val dbHouseKeepingScheduler = new DBHouseKeepingScheduler(db)
 
   val healthcheckController = new Healthcheck
   val applicationController = new Application(wsClient, configuration, db, messagesApi)

--- a/ui/app/com/gu/recipeasy/AppComponents.scala
+++ b/ui/app/com/gu/recipeasy/AppComponents.scala
@@ -11,6 +11,7 @@ import io.getquill._
 import com.gu.recipeasy.db.DB
 
 import scala.concurrent.Future
+import schedule.DBCleaner
 
 class AppComponents(context: Context)
     extends BuiltInComponentsFromContext(context)
@@ -29,6 +30,7 @@ class AppComponents(context: Context)
   applicationLifecycle.addStopHook(() => Future.successful(dbContext.close()))
   val db = new DB(dbContext)
   val messagesApi: MessagesApi = new DefaultMessagesApi(environment, configuration, new DefaultLangs(configuration))
+  val dbScheduler = new DBCleaner(db)
 
   val healthcheckController = new Healthcheck
   val applicationController = new Application(wsClient, configuration, db, messagesApi)

--- a/ui/app/com/gu/recipeasy/AppLoader.scala
+++ b/ui/app/com/gu/recipeasy/AppLoader.scala
@@ -9,12 +9,11 @@ class AppLoader extends ApplicationLoader {
     new LogbackLoggerConfigurator().configure(context.environment)
     val components = new AppComponents(context)
 
-    components.dbHouseKeepingScheduler.start
+    components.dbHouseKeepingScheduler.start()
     components.applicationLifecycle.addStopHook { () =>
       println("Shutting down scheduler")
       Future.successful(components.dbHouseKeepingScheduler.shutdown())
     }
-
     components.application
   }
 }

--- a/ui/app/com/gu/recipeasy/AppLoader.scala
+++ b/ui/app/com/gu/recipeasy/AppLoader.scala
@@ -9,10 +9,10 @@ class AppLoader extends ApplicationLoader {
     new LogbackLoggerConfigurator().configure(context.environment)
     val components = new AppComponents(context)
 
-    components.dbScheduler.start
+    components.dbHouseKeepingScheduler.start
     components.applicationLifecycle.addStopHook { () =>
       println("Shutting down scheduler")
-      Future.successful(components.dbScheduler.shutdown())
+      Future.successful(components.dbHouseKeepingScheduler.shutdown())
     }
 
     components.application

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -4,10 +4,8 @@ import play.api.mvc._
 import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.data._
-import play.api.data.Forms._
 import play.api.data.format.Formats._
 import play.api.i18n.{ I18nSupport, MessagesApi }
-import java.time.OffsetDateTime
 import com.typesafe.scalalogging.StrictLogging
 
 import com.gu.recipeasy.auth.AuthActions
@@ -16,10 +14,8 @@ import com.gu.recipeasy.models._
 import com.gu.recipeasy.views
 import models._
 import models.CuratedRecipeForm._
-import automagic._
 
 class Application(override val wsClient: WSClient, override val conf: Configuration, db: DB, val messagesApi: MessagesApi) extends Controller with AuthActions with I18nSupport with StrictLogging {
-  import Forms._
   import Application._
 
   def index = AuthAction {

--- a/ui/app/schedule/DBCleanSheduler.scala
+++ b/ui/app/schedule/DBCleanSheduler.scala
@@ -38,6 +38,6 @@ class HouseKeepingJob extends Job {
   override def execute(context: JobExecutionContext): Unit = {
     val jobDataMap = context.getJobDetail.getJobDataMap
     val db = jobDataMap.get("DB").asInstanceOf[DB]
-    db.resetStatus
+    db.resetStatus()
   }
 }

--- a/ui/app/schedule/DBCleanSheduler.scala
+++ b/ui/app/schedule/DBCleanSheduler.scala
@@ -1,0 +1,41 @@
+package schedule
+
+import com.gu.recipeasy.db.DB
+import org.quartz.JobBuilder._
+import org.quartz.TriggerBuilder._
+import org.quartz.CronScheduleBuilder._
+import org.quartz.{ Job, JobDataMap, JobExecutionContext }
+import org.quartz.impl.StdSchedulerFactory
+
+class DBCleaner(db: DB) {
+
+  private val scheduler = StdSchedulerFactory.getDefaultScheduler()
+
+  private def buildJobDataMap: JobDataMap = {
+    val map = new JobDataMap()
+    map.put("DB", db.resetStatus)
+    map
+  }
+
+  val jobDetail = newJob(classOf[HouseKeepingJob])
+    .withIdentity("cleanDB")
+    .usingJobData(buildJobDataMap)
+    .build()
+
+  val trigger = newTrigger()
+    .withIdentity("cleanDB")
+    .withSchedule(dailyAtHourAndMinute(17, 20))
+    .build()
+
+  scheduler.scheduleJob(jobDetail, trigger)
+
+  def start(): Unit = scheduler.start()
+  def shutdown(): Unit = scheduler.shutdown()
+
+}
+
+class HouseKeepingJob extends Job {
+  override def execute(context: JobExecutionContext): Unit = {
+    implicit val jobDataMap = context.getJobDetail.getJobDataMap
+  }
+}

--- a/ui/conf/deploy.json
+++ b/ui/conf/deploy.json
@@ -4,7 +4,8 @@
     "recipeasy": {
       "type": "autoscaling",
       "data": {
-        "bucket": "content-api-dist"
+        "bucket": "content-api-dist",
+        "publicReadAcl": false
       }
     },
     "recipeasy-ami-update" : {


### PR DESCRIPTION
Currently, when a recipe is opened its status is set to 'Pending'. If the recipe is skipped (currently this just refreshes the page), or the browser window closed the status remains on 'Pending'.

- Sets all pending recipes' status to 'New' at midnight to allow them to be curated again. 