### PR TITLE
Updating README with a note on the install of Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ First create and set up the PostgreSQL DB using the `init-dev-DB.sh` script. Thi
 * Create the necessary DB schema and users
 * Run any necessary DB migrations using the Flyway sbt plugin
 
+
+**Note**: The latest versions of macOS (e.g. Yosemite, El Capitan and Sierra) sometimes remove some directories in **/usr/local/var/postgres**. When this happens postgres will fail to start and the script will also fail. To prevent this from happening inside **/usr/local/var/postgres/** make sure that the following folders (and subfolders) are created: **pg\_tblspc**, **pg\_twophase**, **pg\_stat**, **pg\_stat\_tmp**, **pg\_replslot**, **pg\_snapshots**, **pg\_stat\_tmp**, **pg\_replslot**, **pg\_snapshots**, **pg\_commit\_ts**, **pg\_logical**, **pg\_logical/snapshots** and **pg\_logical/mappings**.
+
 Once you have a DB, you can run the ETL script:
 
 ```


### PR DESCRIPTION
This updates shows how to deal with a failure of `./init-dev-DB.sh` caused by an incorrect install of Postgres.