### PR TITLE
Postgres install update in init-dev-DB.sh

### DIFF
--- a/init-dev-DB.sh
+++ b/init-dev-DB.sh
@@ -11,6 +11,31 @@ else
   echo Looks like PostgreSQL is already installed.
 fi
 
+# ------------------------------------------------------------------------------
+# The next section repairs possible missing folders whose absence prevent
+# Postgres from starting correctly, This problem occurs with the latest
+# versions of macOS (e.g. Yosemite, El Capitan and Sierra).
+
+DIRS="pg_tblspc
+pg_twophase
+pg_stat
+pg_stat_tmp
+pg_replslot
+pg_snapshots
+pg_stat_tmp
+pg_replslot
+pg_snapshots
+pg_commit_ts
+pg_logical
+pg_logical/snapshots
+pg_logical/mappings"
+for dir in $DIRS
+do
+    mkdir -p "/usr/local/var/postgres/$dir"
+done
+
+# ------------------------------------------------------------------------------
+
 if [ -z "$(pgrep postgres)" ]
 then 
   echo Postgres server does not appear to be running. Starting it as a background process ...


### PR DESCRIPTION
This update ensures that some folders that Postgres needs to run
are actually present before we attemp to start it. This problem
seems to be caused by recent versions of macOS.

The initial set of folders came from
http://stackoverflow.com/questions/25970132/pg-tblspc-missing-after-installation-of-latest-version-of-os-x-yosemite-or-el

and the rest came from actual testing, using a new install of MacOS Sierra.