### PR TITLE
updates etl to include adding images to table

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -65,6 +65,13 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
   private implicit val tagsDecoder: Decoder[TagNames] = jsonbDecoder[TagNames]
   private implicit val imagesDecoder: Decoder[Images] = jsonbDecoder[Images]
 
+  def existingArticlesIds: List[String] = {
+    val action = quote {
+      query[Recipe].map(r => r.articleId)
+    }
+    ctx.run(action)
+  }
+
   def insertAll(recipes: List[Recipe]): Unit = {
     try {
       val action = quote {

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -65,7 +65,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
   private implicit val tagsDecoder: Decoder[TagNames] = jsonbDecoder[TagNames]
   private implicit val imagesDecoder: Decoder[Images] = jsonbDecoder[Images]
 
-  def existingArticlesIds: List[String] = {
+  def existingArticlesIds(): List[String] = {
     val action = quote {
       query[Recipe].map(r => r.articleId)
     }

--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -89,13 +89,16 @@ object ETL extends App {
   }
 
   def processPage(contents: List[Content])(implicit db: DB): Progress = {
-    val progress = contents.foldMap { content =>
+    val existingArticlesIds = db.existingArticlesIds
+    val freshContents = contents.filterNot(c => existingArticlesIds.contains(c.id))
+    val progress = freshContents.foldMap { content =>
       println(s"Processing content ${content.id}")
 
-      val images = ImageExtraction.getImages(content, content.id).toList
-      db.insertImages(images)
-
       val rawRecipes = RecipeExtraction.findRecipes(content.webTitle, content.fields.flatMap(_.body).getOrElse(""))
+      if (rawRecipes.nonEmpty) {
+        val images = ImageExtraction.getImages(content, content.id).toList
+        db.insertImages(images)
+      }
       val parsedRecipes = rawRecipes.map(RecipeParsing.parseRecipe)
       val publicationDate = content.webPublicationDate.map(time => OffsetDateTime.parse(time.iso8601)).getOrElse(OffsetDateTime.now)
 

--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -89,7 +89,7 @@ object ETL extends App {
   }
 
   def processPage(contents: List[Content])(implicit db: DB): Progress = {
-    val existingArticlesIds = db.existingArticlesIds
+    val existingArticlesIds = db.existingArticlesIds()
     val freshContents = contents.filterNot(c => existingArticlesIds.contains(c.id))
     val progress = freshContents.foldMap { content =>
       println(s"Processing content ${content.id}")

--- a/ui/public/javascript/editForm.js
+++ b/ui/public/javascript/editForm.js
@@ -108,7 +108,7 @@ $("body").on("click", ".ingredients-list__button-add", function(){
     newList.find(".ingredient").not(":first").each(function(){
         $(this).remove()
     })
-    newList.find("span").text("")
+    newList.find("textarea").text("")
     renumIngredientsList.call(this)
 })
 


### PR DESCRIPTION
- collects list of articleIds already in the db
- filters content against this list
- if successfully parse recipes from article, add images from that article to db

The DB in prod has been updated. 

JS correction to clear field of dynamically added ingredient. 