### PR TITLE
Riff raff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val ui = (project in file("ui"))
     riffRaffPackageName := "recipeasy",
     riffRaffPackageType := (packageZipTarball in Universal).value,
     riffRaffBuildIdentifier := env("BUILD_NUMBER").getOrElse("DEV"),
+    riffRaffManifestVcsUrl := "git@github.com:guardian/recipeasy.git",
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds")
   ))

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,8 @@ lazy val flywaySettings = Seq(
 lazy val root = (project in file("."))
   .aggregate(ui, common, etl)
 
+def env(key: String): Option[String] = Option(System.getenv(key))
+
 lazy val ui = (project in file("ui"))
   .enablePlugins(PlayScala, RiffRaffArtifact)
   .dependsOn(common)
@@ -46,6 +48,7 @@ lazy val ui = (project in file("ui"))
     routesGenerator := InjectedRoutesGenerator,
     riffRaffPackageName := "recipeasy",
     riffRaffPackageType := (packageZipTarball in Universal).value,
+    riffRaffBuildIdentifier := env("BUILD_NUMBER").getOrElse("DEV"),
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds")
   ))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.5")
 
 resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")


### PR DESCRIPTION
Upgrades to latest version of sbt-riffraff-artifact
Adds `riffRaffManifestVcsUrl` as TeamCity checks out on the server then copies the directory over without git info and so need to specify the value. 