### PR TITLE
adds serves/makes field

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -50,6 +50,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
   }
 
   private implicit val servesEncoder: Encoder[Serves] = jsonbEncoder[Serves]
+  private implicit val detailedServesEncoder: Encoder[DetailedServes] = jsonbEncoder[DetailedServes]
   private implicit val ingredientsListsEncoder: Encoder[IngredientsLists] = jsonbEncoder[IngredientsLists]
   private implicit val detailedIngredientsListsEncoder: Encoder[DetailedIngredientsLists] = jsonbEncoder[DetailedIngredientsLists]
   private implicit val timesEncoder: Encoder[TimesInMins] = jsonbEncoder[TimesInMins]
@@ -58,6 +59,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
   private implicit val imagesEncoder: Encoder[Images] = jsonbEncoder[Images]
 
   private implicit val servesDecoder: Decoder[Serves] = jsonbDecoder[Serves]
+  private implicit val detailedServesDecoder: Decoder[DetailedServes] = jsonbDecoder[DetailedServes]
   private implicit val ingredientsListsDecoder: Decoder[IngredientsLists] = jsonbDecoder[IngredientsLists]
   private implicit val detailedIngredientsListsDecoder: Decoder[DetailedIngredientsLists] = jsonbDecoder[DetailedIngredientsLists]
   private implicit val timesDecoder: Decoder[TimesInMins] = jsonbDecoder[TimesInMins]

--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -26,11 +26,8 @@ case class DetailedServes(
 )
 
 object DetailedServes {
-  def fromServes(s: Option[Serves]): Option[DetailedServes] = {
-    s match {
-      case Some(s) => Some(DetailedServes(ServesType, s))
-      case None => None
-    }
+  def fromServes(serves: Option[Serves]): Option[DetailedServes] = {
+    serves.map(s => DetailedServes(ServesType, s))
   }
 }
 

--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipeDB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipeDB.scala
@@ -8,7 +8,7 @@ case class CuratedRecipeDB(
   id: Long,
   recipeId: String,
   title: String,
-  serves: Option[Serves],
+  serves: Option[DetailedServes],
   ingredientsLists: DetailedIngredientsLists,
   credit: Option[String],
   times: TimesInMins,

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -80,9 +80,12 @@ object Application {
     mapping(
       "title" -> nonEmptyText(maxLength = 200),
       "serves" -> optional(mapping(
-        "from" -> number(min = 1),
-        "to" -> number(min = 1)
-      )(Serves.apply)(Serves.unapply)),
+        "portionType" -> text.transform[PortionType](PortionType.fromString(_), _.toString),
+        "quantity" -> mapping(
+          "from" -> number(min = 1),
+          "to" -> number(min = 1)
+        )(Serves.apply)(Serves.unapply)
+      )(DetailedServes.apply)(DetailedServes.unapply)),
       "ingredientsLists" -> seq(mapping(
         "title" -> optional(nonEmptyText(maxLength = 200)),
         "ingredients" -> seq(mapping(

--- a/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
+++ b/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
@@ -6,7 +6,7 @@ import automagic._
 
 case class CuratedRecipeForm(
   title: String,
-  serves: Option[Serves],
+  serves: Option[DetailedServes],
   ingredientsLists: Seq[DetailedIngredientsList],
   credit: Option[String],
   times: TimesInMins,

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -36,17 +36,14 @@
                         @b4.number( curatedRecipeForm("times")("cooking"), '_label -> "Cooking time", 'placeholder -> "time in minutes", 'min -> 0, 'class -> "form-control-sm")
                     </div>
                     <h2>Servings</h2>
-                    <div class="flex space-children">
-                        <div class="field__serves flex">
-                            @b4.radio( curatedRecipeForm("serves")("portionType"),  options = Seq("ServesType" -> "Serves", "MakesType" -> "Makes"), '_inline -> true, 'label -> "Portion")
-                            <div class="flex field__serves__quantity">
-                                @b4.number( curatedRecipeForm("serves")("quantity")("from"), 'class -> "form-control-sm")
-                                <label class="field__serves__quantity__label">to</label>
-                                @b4.number( curatedRecipeForm("serves")("quantity")("to"), 'class -> "form-control-sm")
-                            </div>
+                    <label><input type="checkbox" id="field__serves-checkbox"> No serving information</label><br>
+                    <div class="field__serves flex">
+                        @b4.radio( curatedRecipeForm("serves")("portionType"),  options = Seq("ServesType" -> "Serves", "MakesType" -> "Makes"), '_inline -> true, 'label -> "Portion")
+                        <div class="flex field__serves__quantity">
+                            @b4.number( curatedRecipeForm("serves")("quantity")("from"), 'class -> "form-control-sm")
+                            <label class="field__serves__quantity__label">to</label>
+                            @b4.number( curatedRecipeForm("serves")("quantity")("to"), 'class -> "form-control-sm")
                         </div>
-                        <h5>Or</h5>
-                        <label><input type="checkbox" id="field__serves-checkbox"> No serving information</label><br>
                     </div>
                     <hr>
                     <h2>Ingredients lists</h2>

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -35,9 +35,18 @@
                         @b4.number( curatedRecipeForm("times")("preparation"), '_label -> "Preparation time", 'placeholder -> "time in minutes", 'min -> 0, 'class -> "form-control-sm")
                         @b4.number( curatedRecipeForm("times")("cooking"), '_label -> "Cooking time", 'placeholder -> "time in minutes", 'min -> 0, 'class -> "form-control-sm")
                     </div>
-                    <div class="flex field__serves">
-                        @b4.number( curatedRecipeForm("serves")("from"), '_label -> "Serves from", 'class -> "form-control-sm")
-                        @b4.number( curatedRecipeForm("serves")("to"), '_label -> "to", 'class -> "form-control-sm")
+                    <h2>Servings</h2>
+                    <div class="flex space-children">
+                        <div class="field__serves flex">
+                            @b4.radio( curatedRecipeForm("serves")("portionType"),  options = Seq("ServesType" -> "Serves", "MakesType" -> "Makes"), '_inline -> true, 'label -> "Portion")
+                            <div class="flex field__serves__quantity">
+                                @b4.number( curatedRecipeForm("serves")("quantity")("from"), 'class -> "form-control-sm")
+                                <label class="field__serves__quantity__label">to</label>
+                                @b4.number( curatedRecipeForm("serves")("quantity")("to"), 'class -> "form-control-sm")
+                            </div>
+                        </div>
+                        <h5>Or</h5>
+                        <label><input type="checkbox" id="field__serves-checkbox"> No serving information</label><br>
                     </div>
                     <hr>
                     <h2>Ingredients lists</h2>

--- a/ui/public/javascript/editForm.js
+++ b/ui/public/javascript/editForm.js
@@ -253,3 +253,22 @@ function renumImages(){
     })
 }
 
+$("body").on("click", "#field__serves-checkbox", function(){
+  if($(this).is(":checked")){
+      $(".field__serves input").each(function(){
+          $(this).attr("disabled", true)
+        })
+
+    } else {
+      $(".field__serves input").each(function(){
+          $(this).attr("disabled", false)
+        })
+    }
+})
+
+$("body").on("click", 'input[name="serves.portionType"]', function(){
+    $(".field__serves__quantity input").each(function(){
+        $(this).attr("required", true)
+    })
+})
+

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -77,12 +77,20 @@ img {
     overflow: scroll;
 }
 
-.field__serves .form-group, .field__times .form-group, .tags .form-control {
+.field__times .form-group, .tags .form-control {
     margin-right: 10px;
 }
 
-.field__serves, .field__serves__quantity {
-  flex-basis: 45%;
+.field__serves .radio-inline{
+    margin-right: 30px;
+}
+
+.field__serves__quantity__label {
+    margin: 0 10px;
+}
+
+.field__serves__quantity {
+  flex-basis: 20%;
 }
 
 .ingredients-list {

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -81,6 +81,10 @@ img {
     margin-right: 10px;
 }
 
+.field__serves, .field__serves__quantity {
+  flex-basis: 45%;
+}
+
 .ingredients-list {
     margin-bottom: 10px;
 }


### PR DESCRIPTION
**MODEL**
- creates `detailedServes` class which includes a field with portionType
- create sealed trait portion type which is either 'serves' or 'makes'
- uses circe to create JSON for adding to curated_recipe table:
```
{"portion": "ServesType", "quantity": {"to": 2, "from": 2}}
```

**UI**
- if the user checks 'No serving information', the serves fields are disabed. This preserves their values on the UI but will not post with form
- if the user selects either radio button AND leaves quantites empty, they cannot submit the form
- if the user does not check 'no serving information' AND has not selected a radio button they can still submit the form

![required](https://cloud.githubusercontent.com/assets/8484757/19308633/83ec95e0-9078-11e6-98a6-0a5f34d555d0.gif)


TODO
- [ ] clean prod database; 36 recipes have been added to DB with old `Serves` model. 
