### PR TITLE
adds logging to ELK stack

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ val commonSettings = Seq(
     "org.postgresql" % "postgresql" % "9.4.1208",
     "io.getquill" %% "quill-jdbc" % "0.9.0",
     "commons-codec" % "commons-codec" % "1.10",
-    "com.github.cb372" %% "automagic" % "0.1"
+    "com.github.cb372" %% "automagic" % "0.1",
+    "com.amazonaws" % "amazon-kinesis-client" % "1.6.2"
   )
 )
 
@@ -45,7 +46,9 @@ lazy val ui = (project in file("ui"))
       "com.gu" %% "configuration-magic-play2-4" % "1.2.0",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
       "com.adrianhurt" %% "play-bootstrap" % "1.1-P25-B4",
-      "org.quartz-scheduler" % "quartz" % "2.2.3"
+      "org.quartz-scheduler" % "quartz" % "2.2.3",
+      "com.gu" % "kinesis-logback-appender" % "1.2.0",
+      "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
     ),
     routesGenerator := InjectedRoutesGenerator,
     riffRaffPackageName := "recipeasy",

--- a/cloudformation/app.yml
+++ b/cloudformation/app.yml
@@ -26,6 +26,9 @@ Parameters:
   SecurityGroupToAccessPostgress:
     Type: 'AWS::EC2::SecurityGroup::Id'
     Description: 'Postgres security group used in recipeasy'
+  LoggingKinesisStream:
+    Description: "The name of the logging kinesis stream",
+    Type: String
 Resources:
   RootRole:
     Type: 'AWS::IAM::Role'
@@ -193,6 +196,33 @@ Resources:
           FromPort: 22
           ToPort: 22
           CidrIp: 77.91.248.0/21
+  KinesisSenderPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: 'kinesis-sender'
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'kinesis:PutRecord'
+              - 'kinesis:PutRecords'
+              - 'kinesis:DescribeStream'
+            Resource: !Sub 'arn:aws:kinesis:${AWS::Region}:${AWS:AccountId}:stream/${LoggingKinesisStream}'
+        Roles:
+          - !Ref RootRole
+  Ec2DescribeTagsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: 'ec2-describe-tags'
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'ec2:DescribeTags'
+            Resource: '*'
+        Roles:
+          - !Ref RootRole
 Outputs:
   LoadBalancer:
     Value:

--- a/ui/app/com/gu/recipeasy/LogStash.scala
+++ b/ui/app/com/gu/recipeasy/LogStash.scala
@@ -1,0 +1,85 @@
+package com.gu.recipeasy
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{ Logger, LoggerContext }
+import ch.qos.logback.core.joran.spi.JoranException
+import ch.qos.logback.core.util.StatusPrinter
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.regions.Region
+import com.gu.cm.Identity
+import com.gu.logback.appender.kinesis.KinesisAppender
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{ LoggerFactory, Logger => SLFLogger }
+import play.api.Mode.Mode
+
+import scala.util.control.NonFatal
+
+case class KinesisAppenderConfig(
+  stream: String,
+  credentialsProvider: AWSCredentialsProviderChain,
+  region: Region,
+  bufferSize: Int = 1000
+)
+
+object LogStash {
+  val logger = LoggerFactory.getLogger("LogStash")
+
+  // assume SLF4J is bound to logback in the current environment
+  lazy val context = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+
+  def makeCustomFields(customFields: Map[String, String]): String = {
+    "{" + (for ((k, v) <- customFields) yield (s""""${k}":"${v}"""")).mkString(",") + "}"
+  }
+
+  def makeLayout(customFields: String) = {
+    val l = new LogstashLayout()
+    l.setCustomFields(customFields)
+    l
+  }
+
+  def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, appenderConfig: KinesisAppenderConfig) = {
+    val a = new KinesisAppender[ILoggingEvent]()
+    a.setStreamName(appenderConfig.stream)
+    a.setRegion(appenderConfig.region.getName)
+    a.setCredentialsProvider(appenderConfig.credentialsProvider)
+    a.setBufferSize(appenderConfig.bufferSize)
+
+    a.setContext(context)
+    a.setLayout(layout)
+
+    layout.start()
+    a.start()
+    a
+  }
+
+  def init(config: KinesisAppenderConfig, mode: Mode, identity: Identity) {
+
+    val FACTS: Map[String, String] = try {
+      val facts: Map[String, String] = {
+        logger.info("Loading facts from AWS instance tags")
+        Map("app" -> identity.app, "stack" -> identity.stack, "stage" -> identity.stage)
+      }
+      logger.info(s"Using facts: $facts")
+      facts
+    } catch {
+      case NonFatal(e) =>
+        logger.error("Failed to get facts", e)
+        Map.empty
+    }
+
+    try {
+      logger.info("Configuring logging to send to LogStash")
+      val layout = makeLayout(makeCustomFields(FACTS))
+      val appender = makeKinesisAppender(layout, context, config)
+      val rootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[Logger]
+      rootLogger.addAppender(appender)
+      logger.info("LogStash configuration completed")
+    } catch {
+      case e: JoranException => // ignore, errors will be printed below
+      case NonFatal(e) =>
+        logger.error("Error while initialising LogStash", e)
+    }
+
+    StatusPrinter.printInCaseOfErrorsOrWarnings(context)
+  }
+}

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -16,7 +16,6 @@ import models._
 import models.CuratedRecipeForm._
 
 class Application(override val wsClient: WSClient, override val conf: Configuration, db: DB, val messagesApi: MessagesApi) extends Controller with AuthActions with I18nSupport with StrictLogging {
-  import Application._
 
   def index = AuthAction {
     Ok(views.html.app("Recipeasy"))
@@ -30,6 +29,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
         val curatedRecipeForm = CuratedRecipeForm.toForm(curatedRecipe)
         val images = db.getImages(r.articleId)
         db.setRecipeStatus(r.id, "Pending")
+        logger.info(s"Curating ${r.id}, ${r.title}")
         Ok(views.html.recipe(Application.curatedRecipeForm.fill(curatedRecipeForm), r.id, r.body, r.articleId, shouldShowButtons = true, images))
       }
       case None => NotFound

--- a/ui/conf/application.conf
+++ b/ui/conf/application.conf
@@ -3,7 +3,6 @@
 play.crypto.secret = "changeme"
 play.i18n.langs = [ "en" ]
 play.application.loader = AppLoader
-
 play.application.name="recipeasy"
 
 # Web services
@@ -25,4 +24,9 @@ db {
   ctx.dataSource.portNumber=5432
   ctx.dataSource.serverName=localhost
   ctx.connectionTimeout=30000
+}
+
+aws {
+  region=""
+  logging.kinesisStreamName=""
 }


### PR DESCRIPTION
Sets up logging. Currently, recipeasy logs the PSQL commands create by quill and when a curated recipe is loaded. Tested  locally ☺︎

- sends logs to ELK stack


TODO 
- [ ] update CF