### PR TITLE
adds byline field to capi request

### DIFF
--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -50,7 +50,7 @@ object ETL extends App {
     .pageSize(100)
     .contentType("article") // there are some video recipes, don't want those
     .tag("tone/recipes,-lifeandstyle/series/the-lunch-box,-lifeandstyle/series/last-bites,-lifeandstyle/series/breakfast-of-champions")
-    .showFields("main,body")
+    .showFields("main,body,byline")
     .showElements("image")
 
   val dbContext = new JdbcContext[PostgresDialect, SnakeCase]("db.ctx")


### PR DESCRIPTION
If we run ETL again, this will populate the credit field. 

- adds byline field to capi request