### PR TITLE
adds ability to update existing articles if they are not already edited

### DIFF
--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -89,9 +89,7 @@ object ETL extends App {
   }
 
   def processPage(contents: List[Content])(implicit db: DB): Progress = {
-
-    processPageWhenInserting(contents)
-    processPageWhenUpdating(contents)
+    Progress.progressMonoid.combine(processPageWhenInserting(contents), processPageWhenUpdating(contents))
   }
 
   def processPageWhenInserting(contents: List[Content])(implicit db: DB): Progress = {

--- a/ui/conf/application.conf
+++ b/ui/conf/application.conf
@@ -27,6 +27,6 @@ db {
 }
 
 aws {
-  region=""
+  region="eu-west-1"
   logging.kinesisStreamName=""
 }


### PR DESCRIPTION
Adds ability to safely run ETL to add new articles, and update existing recipes if it is safe to do so.

An article is safe to update if none of its corresponding recipes have been edited (i.e. status field is 'New' and not 'Pending' or 'Curated' or 'Impossible'). This is because once an article has been edited future edits will be built upon this version and not the original version parsed by the ETL. The new ETL could effect the number of recipes parsed from an article and update the wrong recipe in the table.

List of safe to update recipes is found by making a diff of list of article_ids with existing recipes and list of article_ids for recipes with status != 'New'. 

- splits up process to allow for updating and inserting
- amends ETL to update safe existing articles
- images are only added if the article is fresh content

Tested locally. 

Rough diagram of what the ETL does for reference: 

![etl 1](https://cloud.githubusercontent.com/assets/8484757/19527649/b02fe44c-9620-11e6-9778-e58a9c48c8f4.jpg)
