### PR TITLE
only inserts images once per article

### DIFF
--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -129,9 +129,7 @@ object ETL extends App {
   def getRecipes(content: Content)(insertImages: List[ImageDB] => Unit): Seq[Recipe] = {
 
     val rawRecipes: Seq[RawRecipe] = RecipeExtraction.findRecipes(content.webTitle, content.fields.flatMap(_.body).getOrElse(""))
-    rawRecipes.foreach{ r =>
-      insertImages(ImageExtraction.getImages(content, content.id).toList)
-    }
+    if (rawRecipes.nonEmpty) { insertImages(ImageExtraction.getImages(content, content.id).toList) }
     val parsedRecipes = rawRecipes.map(RecipeParsing.parseRecipe)
     val publicationDate = content.webPublicationDate.map(time => OffsetDateTime.parse(time.iso8601)).getOrElse(OffsetDateTime.now)
 


### PR DESCRIPTION
If an article has recipes extract, we only want to add images from the article to `image` table once.

- only runs add images once per piece of content rather than for each recipe
- prod DB has been updated to remove duplicated images. 