### PR TITLE
Add support for date comparison

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/ContextWrapper.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/ContextWrapper.scala
@@ -1,0 +1,18 @@
+package com.gu.recipeas.db
+
+import com.typesafe.config.{ Config => TypesafeConfig }
+import io.getquill.{ ImplicitQuery, JdbcContext, PostgresDialect, SnakeCase }
+import java.time.OffsetDateTime
+
+trait ContextWrapper {
+  val config: TypesafeConfig
+  lazy val dbContext = new JdbcContext[PostgresDialect, SnakeCase](config.getConfig("db.ctx")) with ImplicitQuery with Quotes
+
+  trait Quotes {
+    this: JdbcContext[_, _] =>
+    implicit class DateTimeQuotes(left: OffsetDateTime) {
+      def >(right: OffsetDateTime) = quote(infix"$left > $right".as[Boolean])
+      def <(right: OffsetDateTime) = quote(infix"$left < $right".as[Boolean])
+    }
+  }
+}

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -4,22 +4,22 @@ import java.sql.Types
 import java.time.{ OffsetDateTime, ZoneOffset }
 import java.util.Date
 
+import com.gu.recipeas.db.ContextWrapper
 import com.gu.recipeasy.models._
 import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.syntax._
 import io.circe.parser._
-import io.getquill._
 import org.postgresql.util.PGobject
 
 import scala.reflect.ClassTag
 
-class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
-  import ctx._
+class DB(contextWrapper: ContextWrapper) {
+  import contextWrapper.dbContext._
 
   private implicit val encodePublicationDate = mappedEncoding[OffsetDateTime, Date](d => Date.from(d.toInstant))
-  private implicit val encodeStatus = mappedEncoding[Status, String](_.toString())
   private implicit val decodePublicationDate = mappedEncoding[Date, OffsetDateTime](d => OffsetDateTime.ofInstant(d.toInstant, ZoneOffset.UTC))
+  private implicit val encodeStatus = mappedEncoding[Status, String](_.toString())
   private implicit val decodeStatus = mappedEncoding[String, Status](d => d match {
     case "New" => New
     case "Curated" => Curated
@@ -73,7 +73,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     val action = quote {
       query[Recipe].map(r => r.articleId).distinct
     }
-    ctx.run(action)
+    contextWrapper.dbContext.run(action)
   }
 
   //an article can have multiple recipes associated with it
@@ -82,7 +82,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     val action = quote {
       query[Recipe].filter(_.status != "New").map(r => r.articleId).distinct
     }
-    ctx.run(action)
+    contextWrapper.dbContext.run(action)
   }
 
   def insertAll(recipes: List[Recipe]): Unit = {
@@ -90,7 +90,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
       val action = quote {
         liftQuery(recipes).foreach(r => query[Recipe].insert(r))
       }
-      ctx.run(action)
+      contextWrapper.dbContext.run(action)
     } catch {
       case e: java.sql.BatchUpdateException => throw e.getNextException
     }
@@ -102,7 +102,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
         liftQuery(recipes).foreach(r =>
           query[Recipe].filter(_.id == r.id).update(r))
       }
-      ctx.run(action)
+      contextWrapper.dbContext.run(action)
     } catch {
       case e: java.sql.BatchUpdateException => throw e.getNextException
     }
@@ -114,7 +114,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
       val action = quote {
         liftQuery(images).foreach(i => table.insert(i))
       }
-      ctx.run(action)
+      contextWrapper.dbContext.run(action)
     } catch {
       case e: java.sql.BatchUpdateException => throw e.getNextException
     }
@@ -125,30 +125,30 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     val a = quote {
       table.filter(i => i.articleId == lift(articleId))
     }
-    ctx.run(a)
+    contextWrapper.dbContext.run(a)
   }
 
   // ---------------------------------------------
   // Original Recipes
 
   def getOriginalRecipe(recipeId: String): Option[Recipe] = {
-    ctx.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId))).headOption
+    contextWrapper.dbContext.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId))).headOption
   }
 
   def getOriginalRecipeInNewStatus(): Option[Recipe] = {
-    ctx.run(quote(query[Recipe]).filter(r => r.status == "New").sortBy(r => r.publicationDate)(Ord.desc).take(1)).headOption
+    contextWrapper.dbContext.run(quote(query[Recipe]).filter(r => r.status == "New").sortBy(r => r.publicationDate)(Ord.desc).take(1)).headOption
   }
 
   def setOriginalRecipeStatus(recipeId: String, status: String): Unit = {
     val a = quote {
       query[Recipe].filter(r => r.id == lift(recipeId)).update(_.status -> lift(status))
     }
-    ctx.run(a)
+    contextWrapper.dbContext.run(a)
   }
 
   def resetOriginalRecipesStatus(): Unit = {
     val a = quote(query[Recipe].filter(_.status == "Pending").update(_.status -> "New"))
-    ctx.run(a)
+    contextWrapper.dbContext.run(a)
   }
 
   // ---------------------------------------------
@@ -159,7 +159,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     val a = quote {
       table.filter(r => r.recipeId == lift(recipeId))
     }
-    ctx.run(a).headOption
+    contextWrapper.dbContext.run(a).headOption
   }
 
   def getCuratedRecipe(): Option[CuratedRecipeDB] = {
@@ -167,7 +167,7 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
     val a = quote {
       (table.sortBy(r => r.id)(Ord.desc).take(1))
     }
-    ctx.run(a).headOption
+    contextWrapper.dbContext.run(a).headOption
   }
 
   def insertCuratedRecipe(cr: CuratedRecipe): Unit = {
@@ -177,18 +177,22 @@ class DB(ctx: JdbcContext[PostgresDialect, SnakeCase]) {
       val action = quote {
         table.insert(lift(crDB)).returning(_.id)
       }
-      ctx.run(action)
+      contextWrapper.dbContext.run(action)
     } catch {
       case e: java.sql.BatchUpdateException => throw e.getNextException
     }
   }
 
+  def resetStatus(): Unit = {
+    val a = quote(query[Recipe].filter(_.status == "Pending").update(_.status -> "Curated"))
+    contextWrapper.dbContext.run(a)
+  }
   def deleteCuratedRecipeByRecipeId(recipeId: String) = {
     val table = quote(query[CuratedRecipeDB].schema(_.entity("curatedRecipe")))
     val a = quote {
       table.filter(r => r.recipeId == lift(recipeId)).delete
     }
-    ctx.run(a)
+    contextWrapper.dbContext.run(a)
   }
 
 }


### PR DESCRIPTION
Makes it possible to compare recipe publication date using quill by adding support for < and > operators. 
- Db context has been abstracted into a wrapper which defines the trait quote. 
- Context created then extends this trait. 
- Updates to UI and ETL to support change.

Thanks @LATaylor-guardian @tomrf1 
