### PR TITLE
hours+minutes update in recipe times

### DIFF
--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -128,9 +128,11 @@ object Application {
       )(DetailedIngredientsList.apply)(DetailedIngredientsList.unapply)),
       "credit" -> optional(text(maxLength = 200)),
       "times" -> mapping(
-        "preparation" -> optional(of[Double]),
-        "cooking" -> optional(of[Double])
-      )(TimesInMins.apply)(TimesInMins.unapply),
+        "preparationHours" -> optional(of[Double]),
+        "preparationMinutes" -> optional(of[Double]),
+        "cookingHours" -> optional(of[Double]),
+        "cookingMinutes" -> optional(of[Double])
+      )(TimesInMinsAdapted.apply)(TimesInMinsAdapted.unapply),
       "steps" -> seq(text),
       "tags" -> mapping(
         "cuisine" -> seq(text),

--- a/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
+++ b/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
@@ -9,7 +9,7 @@ case class CuratedRecipeForm(
   serves: Option[DetailedServes],
   ingredientsLists: Seq[DetailedIngredientsList],
   credit: Option[String],
-  times: TimesInMins,
+  times: TimesInMinsAdapted,
   steps: Seq[String],
   tags: FormTags,
   images: Seq[Image]

--- a/ui/app/com/gu/recipeasy/views/layout.scala.html
+++ b/ui/app/com/gu/recipeasy/views/layout.scala.html
@@ -12,8 +12,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.11.2/css/bootstrap-select.min.css">
     <script src="https://code.jquery.com/jquery-2.1.4.min.js" integrity="sha384-R4/ztc4ZlRqWjqIuvf6RX5yb/v90qNGx6fS48N0tRxiGkqveZETq72KgDVJCp2TC" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/js/bootstrap.min.js" integrity="sha384-VjEeINv9OSwtWFLAtmc4JCtEJXXBub00gtSnszmspDLCtC0I4z4nqz7rEFbIZLLU" crossorigin="anonymous"></script>
-
-
 </head>
 <body>
     @content

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -42,8 +42,20 @@
                     @b4.text( curatedRecipeForm("title"), '_label -> "Recipe title", 'class -> "form-control-sm")
                     @b4.text( curatedRecipeForm("credit"), '_label -> "Chef/Cook", 'class -> "form-control-sm typeahead")
                     <div class="flex field__times">
-                        @b4.number( curatedRecipeForm("times")("preparation"), '_label -> "Preparation time", 'placeholder -> "time in minutes", 'min -> 0, 'class -> "form-control-sm")
-                        @b4.number( curatedRecipeForm("times")("cooking"), '_label -> "Cooking time", 'placeholder -> "time in minutes", 'min -> 0, 'class -> "form-control-sm")
+                        <div>
+                            <label class="">Preparation time</label>
+                            <div class="flex">
+                                @b4.number( curatedRecipeForm("times")("preparationHours"), '_label -> "hours", 'placeholder -> "00", 'min -> 0, 'class -> "form-control-sm width-80")
+                                @b4.number( curatedRecipeForm("times")("preparationMinutes"), '_label -> "minutes", 'placeholder -> "00", 'min -> 0, 'class -> "form-control-sm width-80")
+                            </div>
+                        </div>
+                        <div>
+                            <label class="">Cooking time</label>
+                            <div class="flex">
+                                @b4.number( curatedRecipeForm("times")("cookingHours"), '_label -> "hours", 'placeholder -> "00", 'min -> 0, 'class -> "form-control-sm width-80")
+                                @b4.number( curatedRecipeForm("times")("cookingMinutes"), '_label -> "minutes", 'placeholder -> "00", 'min -> 0, 'class -> "form-control-sm width-80")
+                            </div>
+                        </div>
                     </div>
                     <h2>Servings</h2>
                     <label><input type="checkbox" id="field__serves-checkbox"> No serving information</label><br>

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -2,7 +2,8 @@ img, video {
     max-width: 100%;
     height: auto;
 }
-/*GENERICS */
+
+/* GENERICS */
 
 .flex {
     display: flex;
@@ -88,11 +89,19 @@ img, video {
     overflow: scroll;
 }
 
-.field__times .form-group, .tags .form-control {
+.field__times .form-group {
     margin-right: 10px;
 }
 
-.field__serves .radio-inline{
+.width-80 {
+    width:80px;
+}
+
+.tags .form-control {
+    margin-right: 10px;
+}
+
+.field__serves .radio-inline {
     margin-right: 30px;
 }
 

--- a/ui/test/com/gu/recipeasy/ApplicationSpec.scala
+++ b/ui/test/com/gu/recipeasy/ApplicationSpec.scala
@@ -41,7 +41,7 @@ class recipeConversion extends FlatSpec with Matchers {
       serves = None,
       ingredientsLists = detailedBreakfast,
       credit = None,
-      times = TimesInMins(None, None),
+      times = TimesInMinsAdapted(None, None, None, None),
       steps = Steps(List.empty),
       tags = Tags(List.empty),
       images = Images(List.empty)


### PR DESCRIPTION
From the User Interface, this commit moves from

![screen shot 2016-11-08 at 17 44 20](https://cloud.githubusercontent.com/assets/6035518/20110198/4e94dd12-a5db-11e6-956c-42e81195a5f1.png)

to

![screen shot 2016-11-08 at 17 46 51](https://cloud.githubusercontent.com/assets/6035518/20110240/7d7b6650-a5db-11e6-874a-6c7cc666040e.png)

Note that this was done without changing the database model (essentially without changing the definition of `case class CuratedRecipeDB`)

Note that this is the first of two commits. The second commit will ensure that minutes always remain in the range `[0,60]`.

