### PR TITLE
Top Banner updated with new messages and a skip button on create step only

### DIFF
--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -26,19 +26,26 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
 
   def viewRecipe(id: String) = Action { implicit request =>
     val recipe = db.getOriginalRecipe(id)
-    curatedRecipedEditor(recipe, editable = false, "")
+    curatedRecipedEditor(recipe, editable = false, pageTopMessage = "", showSkipThisRecipeButton = false)
   }
 
   def curateRecipe(id: String) = Action { implicit request =>
     val recipe = db.getOriginalRecipe(id)
-    curatedRecipedEditor(recipe, editable = true, "Recipe Curation")
+    curatedRecipedEditor(recipe, editable = true, pageTopMessage = "Creation | Pass 1/3", showSkipThisRecipeButton = true)
   }
 
   def verifyRecipe(id: String) = Action { implicit request =>
     val recipe = db.getOriginalRecipe(id)
     // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
     // But we need to record the fact that the recipe is being verified.
-    curatedRecipedEditor(recipe, editable = true, "Recipe Verification")
+    curatedRecipedEditor(recipe, editable = true, pageTopMessage = "Verification | Pass 2/3", showSkipThisRecipeButton = false)
+  }
+
+  def finalCheckRecipe(id: String) = Action { implicit request =>
+    val recipe = db.getOriginalRecipe(id)
+    // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
+    // But we need to record the fact that the recipe is being verified.
+    curatedRecipedEditor(recipe, editable = true, pageTopMessage = "Final Check | Pass 3/3", showSkipThisRecipeButton = false)
   }
 
   def curateOneRecipeInNewStatus = Action { implicit request =>
@@ -49,7 +56,12 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     }
   }
 
-  private[this] def curatedRecipedEditor(recipe: Option[Recipe], editable: Boolean, pageTopMessage: String)(implicit req: RequestHeader) = {
+  private[this] def curatedRecipedEditor(
+    recipe: Option[Recipe],
+    editable: Boolean,
+    pageTopMessage: String,
+    showSkipThisRecipeButton: Boolean
+  )(implicit req: RequestHeader) = {
     recipe match {
       case Some(r) => {
 
@@ -70,7 +82,8 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
           r.articleId,
           shouldShowButtons = editable,
           images,
-          pageTopMessage
+          pageTopMessage,
+          showSkipThisRecipeButton
         ))
 
       }

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -5,21 +5,27 @@
         articleId: String,
         shouldShowButtons: Boolean,
         images: List[ImageDB],
-        pageTopMessage: String)(implicit messages: play.api.i18n.Messages, request: RequestHeader)
+        pageTopMessage: String,
+        showSkipThisRecipeButton: Boolean)(implicit messages: play.api.i18n.Messages, request: RequestHeader)
 @import helper.CSRF
 @implicitFC = @{ b4.vertical.fieldConstructor }
 @link = @{ "https://www.theguardian.com/" + articleId }
 
 @layout("Recipeasy"){
 <div class="page-top-banner">
-    @pageTopMessage
+    @if(showSkipThisRecipeButton){
+        <div style="float:right;">
+            <a href="@routes.Application.curateOneRecipeInNewStatus" class="btn btn-danger recipe__original__skip-button">Skip this recipe</a>
+        </div>
+    }
+    <div style="padding-top:8px;">
+        @pageTopMessage
+    </div>
 </div>
 <div class="recipe container-fluid">
     <div class="row">
         <div class="recipe__original col-md-5">
-            <div class="flex centre-children">
-                <a href="@routes.Application.curateOneRecipeInNewStatus" class="btn btn-danger recipe__original__skip-button">Skip this recipe</a>
-            </div>
+
             <h2>Please fill in the form with this recipe</h2>
             <p>If some details are missing, <a href=@link target="_blank">click here for link to original article</a></p>
             <hr>

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -43,6 +43,7 @@ img, video {
     margin-bottom: 20px;
     color:white;
     font-weight: bold;
+    height:55px;
 }
 
 /* RECIPE ORIGINAL */
@@ -84,7 +85,7 @@ img, video {
 
 .recipe__form {
     position: fixed;
-    top: 50px;
+    top: 60px;
     bottom: 50px;
     overflow: scroll;
 }


### PR DESCRIPTION
This update is purely functional (to implement the new positioning of the top banner, the new messages and the the skip button appearing only at creation step). Style to be updated in coming commit.

![screen shot 2016-11-14 at 15 34 24](https://cloud.githubusercontent.com/assets/6035518/20270690/04a7bf2c-aa80-11e6-9f6c-74f40e9dcf06.png)

![screen shot 2016-11-14 at 15 34 39](https://cloud.githubusercontent.com/assets/6035518/20270697/0a2ba1ac-aa80-11e6-8c81-b4ca91c7d7db.png)

![screen shot 2016-11-14 at 15 34 48](https://cloud.githubusercontent.com/assets/6035518/20270701/0e126706-aa80-11e6-870b-93d27bc4da38.png)

