### PR TITLE
Implement the updated creation/parsing and verification workflow

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
@@ -20,9 +20,26 @@ case class Steps(steps: Seq[String])
 sealed trait Status
 
 case object New extends Status
-case object Curated extends Status
-case object Impossible extends Status
 case object Pending extends Status
+case object Curated extends Status
+case object Verified extends Status
+case object Finalised extends Status
+case object Impossible extends Status
+
+/*
+
+`New` is brand new not looked at
+
+`Pending` means it is currently being looked at
+    This is used to prevent two `New` recipes to be curated by two people at the same time
+    So only `New` (non `Pending` recipes are being displayed in the original curation/parsing process)
+
+`Curated` means it has been parsed (and therefore there is a record in the curated_recipe table)
+
+`Verified` that it has been verified once
+`Finalised` that it has been verified twice
+
+ */
 
 case class IngredientsLists(lists: Seq[IngredientsList])
 

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -88,7 +88,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
 
         /* if recipe has not being edited yet, mark as currently edited */
         if (r.status == New && editable) {
-          db.setOriginalRecipeStatus(r.id, "Pending")
+          db.setOriginalRecipeStatus(r.id, Pending)
         }
 
         val curatedRecipe = db.getCuratedRecipeByRecipeId(r.id).map(CuratedRecipe.fromCuratedRecipeDB) getOrElse CuratedRecipe.fromRecipe(r)
@@ -130,7 +130,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
       val curatedRecipeWithId = curatedRecipeWithoutId.copy(recipeId = recipeId, id = 0L)
       db.deleteCuratedRecipeByRecipeId(recipeId)
       db.insertCuratedRecipe(curatedRecipeWithId)
-      db.setOriginalRecipeStatus(recipeId, "Curated")
+      db.moveStatusForward(recipeId)
       Redirect(routes.Application.curateOneRecipeInNewStatus)
     })
   }


### PR DESCRIPTION
This change introduces two utility functions 

1. `getOriginalRecipeStatus(recipeId: String): Option[Status]`, and 
2. `setOriginalRecipeStatus(recipeId: String, s: Status)`

and use them as the basis for implementing the new verification workflow...
`New` (-> `Pending`) -> `Curated` -> `Verified` -> `Finalised` 
...performed by `moveStatusForward(recipeId: String)`