### PR TITLE
Correct display of time in hours and minutes.

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -70,19 +70,27 @@ case class TimesInMins(
 )
 
 object TimesInMinsAdapted {
-  def preparationTimeInMinutes(cr: CuratedRecipe): Double = {
-    cr.times.preparationHours.getOrElse(0.toDouble) * 60.toDouble + cr.times.preparationMinutes.getOrElse(0.toDouble)
+  def preparationTimeInMinutes(cr: CuratedRecipe): Int = {
+    cr.times.preparationHours.getOrElse(0) * 60 + cr.times.preparationMinutes.getOrElse(0)
   }
-  def cookingTimeInMinutes(cr: CuratedRecipe): Double = {
-    cr.times.cookingHours.getOrElse(0.toDouble) * 60.toDouble + cr.times.cookingMinutes.getOrElse(0.toDouble)
+  def cookingTimeInMinutes(cr: CuratedRecipe): Int = {
+    cr.times.cookingHours.getOrElse(0) * 60 + cr.times.cookingMinutes.getOrElse(0)
+  }
+  def normalisedTimes(cr: CuratedRecipe): TimesInMinsAdapted = {
+    TimesInMinsAdapted(
+      Some(preparationTimeInMinutes(cr) / 60),
+      Some(preparationTimeInMinutes(cr) % 60),
+      Some(cookingTimeInMinutes(cr) / 60),
+      Some(cookingTimeInMinutes(cr) % 60)
+    )
   }
 }
 
 case class TimesInMinsAdapted(
-  preparationHours: Option[Double],
-  preparationMinutes: Option[Double],
-  cookingHours: Option[Double],
-  cookingMinutes: Option[Double]
+  preparationHours: Option[Int],
+  preparationMinutes: Option[Int],
+  cookingHours: Option[Int],
+  cookingMinutes: Option[Int]
 )
 
 sealed trait CookingUnit {
@@ -241,7 +249,7 @@ object CuratedRecipe {
     transform[CuratedRecipeDB, CuratedRecipe](
       r,
       "tags" -> getFullTags(r.tags),
-      "times" -> TimesInMinsAdapted(None, r.times.preparation, None, r.times.cooking)
+      "times" -> TimesInMinsAdapted(None, r.times.preparation.map(t => t.toInt), None, r.times.cooking.map(t => t.toInt))
     )
   }
 

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -163,10 +163,10 @@ object Application {
       )(DetailedIngredientsList.apply)(DetailedIngredientsList.unapply)),
       "credit" -> optional(text(maxLength = 200)),
       "times" -> mapping(
-        "preparationHours" -> optional(of[Double]),
-        "preparationMinutes" -> optional(of[Double]),
-        "cookingHours" -> optional(of[Double]),
-        "cookingMinutes" -> optional(of[Double])
+        "preparationHours" -> optional(of[Int]),
+        "preparationMinutes" -> optional(of[Int]),
+        "cookingHours" -> optional(of[Int]),
+        "cookingMinutes" -> optional(of[Int])
       )(TimesInMinsAdapted.apply)(TimesInMinsAdapted.unapply),
       "steps" -> seq(text),
       "tags" -> mapping(

--- a/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
+++ b/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
@@ -20,6 +20,7 @@ object CuratedRecipeForm {
   def toForm(r: CuratedRecipe): CuratedRecipeForm = {
     transform[CuratedRecipe, CuratedRecipeForm](
       r,
+      "times" -> TimesInMinsAdapted.normalisedTimes(r),
       "ingredientsLists" -> r.ingredientsLists.lists,
       "steps" -> r.steps.steps,
       "tags" -> FormTags(r.tags),


### PR DESCRIPTION
This change makes the preparation and cooking time being correctly displayed online.
The times which are stored in minutes are now correctly reported as hours+minutes.

Also note a small change in the definition of `TimesInMinsAdapted`, to ensure that
the time are reported as integers instead of doubles on the display.

![screen shot 2016-11-16 at 11 18 57](https://cloud.githubusercontent.com/assets/6035518/20345623/ed2b6eb8-abef-11e6-9184-c75cabd5bada.png)

![screen shot 2016-11-16 at 11 18 03](https://cloud.githubusercontent.com/assets/6035518/20345641/058bfd38-abf0-11e6-9eca-8085a9cbd532.png)


