### PR TITLE
Better top message

### DIFF
--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -28,7 +28,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
 
   def viewRecipe(id: String) = AuthAction { implicit request =>
     val recipe = db.getOriginalRecipe(id)
-    curatedRecipedEditor(recipe, editable = false, pageTopMessage = "")
+    curatedRecipedEditor(recipe, editable = false)
   }
 
   private def isShowCreation(): Boolean = {
@@ -54,22 +54,23 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
   }
 
   def curateRecipe(id: String) = AuthAction { implicit request =>
+    db.setOriginalRecipeStatus(id, Pending)
     val recipe = db.getOriginalRecipe(id)
-    curatedRecipedEditor(recipe, editable = true, pageTopMessage = "Creation | Pass 1/3")
+    curatedRecipedEditor(recipe, editable = true)
   }
 
   def verifyRecipe(id: String) = AuthAction { implicit request =>
     val recipe = db.getOriginalRecipe(id)
     // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
     // But we need to record the fact that the recipe is being verified.
-    curatedRecipedEditor(recipe, editable = true, pageTopMessage = "Verification | Pass 2/3")
+    curatedRecipedEditor(recipe, editable = true)
   }
 
   def finalCheckRecipe(id: String) = AuthAction { implicit request =>
     val recipe = db.getOriginalRecipe(id)
     // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
     // But we need to record the fact that the recipe is being verified.
-    curatedRecipedEditor(recipe, editable = true, pageTopMessage = "Final Check | Pass 3/3")
+    curatedRecipedEditor(recipe, editable = true)
   }
 
   def curateOneRecipeInNewStatus = AuthAction { implicit request =>
@@ -82,8 +83,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
 
   private[this] def curatedRecipedEditor(
     recipe: Option[Recipe],
-    editable: Boolean,
-    pageTopMessage: String
+    editable: Boolean
   )(implicit req: RequestHeader) = {
     recipe match {
       case Some(r) => {
@@ -103,9 +103,8 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
           r.id,
           r.body,
           r.articleId,
-          shouldShowButtons = editable,
+          editable,
           images,
-          pageTopMessage,
           r.status
         ))
 

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -5,11 +5,20 @@
         articleId: String,
         shouldShowButtons: Boolean,
         images: List[ImageDB],
-        pageTopMessage: String,
         status: RecipeStatus)(implicit messages: play.api.i18n.Messages, request: RequestHeader)
 @import helper.CSRF
 @implicitFC = @{ b4.vertical.fieldConstructor }
 @link = @{ "https://www.theguardian.com/" + articleId }
+@pageTopMessage(status: RecipeStatus) = @{
+    status match {
+        case New        => "Creation | Pass 1/3"
+        case Pending    => "Creation | Pass 1/3"
+        case Curated    => "Verification | Pass 2/3"
+        case Verified   => "Final Check | Pass 3/3"
+        case Finalised  => "Final Check | Pass 3/3"
+        case _ => ""
+    }
+}
 @showSkipThisRecipeButton(status: RecipeStatus) = @{
     status match {
         case New     => true
@@ -19,10 +28,11 @@
 }
 @topBannerStatusClass(status: RecipeStatus) = @{
     status match {
-        case New       => "top-banner-phase-creation"
-        case Pending   => "top-banner-phase-creation"
-        case Curated   => "top-banner-phase-verification"
-        case Verified  => "top-banner-phase-final"
+        case New        => "top-banner-phase-creation"
+        case Pending    => "top-banner-phase-creation"
+        case Curated    => "top-banner-phase-verification"
+        case Verified   => "top-banner-phase-final"
+        case Finalised  => "top-banner-phase-final"
         case _ => ""
     }
 }
@@ -34,7 +44,7 @@
             <img style="height:55px;" src="@routes.Assets.versioned("images/top-banner-knife-and-fork.png")" alt="icon" />
         </div>
         <div class="top-banner-phase @topBannerStatusClass(status)" style="margin-right:10px;">
-            @pageTopMessage
+            @pageTopMessage(status)
         </div>
         @if(showSkipThisRecipeButton(status)){
             <div style="padding-top:15px;margin-right:10px;">


### PR DESCRIPTION
1. Correct a possible mismatch between the top message and the additional instruction string at the top of a recipe page

2. If somebody visits the curation url, then the recipe is put in `Pending` state (regardless of its previous state).

