### PR TITLE
Introduce a new recipe status

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
@@ -20,6 +20,7 @@ case class Steps(steps: Seq[String])
 sealed trait RecipeStatus
 
 case object New extends RecipeStatus
+case object Ready extends RecipeStatus
 case object Pending extends RecipeStatus
 case object Curated extends RecipeStatus
 case object Verified extends RecipeStatus

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -113,6 +113,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
   def statusDistribution = AuthAction { implicit request =>
     val distribution: Map[RecipeStatus, Long] = Map(
       New -> db.countRecipesInGivenStatus(New),
+      Ready -> db.countRecipesInGivenStatus(Ready),
       Pending -> db.countRecipesInGivenStatus(Pending),
       Curated -> db.countRecipesInGivenStatus(Curated),
       Verified -> db.countRecipesInGivenStatus(Verified),

--- a/ui/app/com/gu/recipeasy/views/statusdistribution.scala.html
+++ b/ui/app/com/gu/recipeasy/views/statusdistribution.scala.html
@@ -14,6 +14,10 @@
                 <td>@distribution(New)</td>
             </tr>
             <tr>
+                <td>Ready</td>
+                <td>@distribution(Ready)</td>
+            </tr>
+            <tr>
                 <td>Pending</td>
                 <td>@distribution(Pending)</td>
             </tr>


### PR DESCRIPTION
Working towards the split between correctly and incorrectly parsed recipes, introducing a new recipe status: `Ready`. That is going to stand between `New` and `Pending`. In essence `Ready` recipes will be the `New` recipes that have been correctly parsed. 
