### PR TITLE
Introduce Recipe Preparation

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -135,6 +135,10 @@ class DB(contextWrapper: ContextWrapper) {
   // ---------------------------------------------
   // Original Recipes
 
+  def getRecipes(): List[Recipe] = {
+    contextWrapper.dbContext.run(quote(query[Recipe]))
+  }
+
   def getOriginalRecipe(recipeId: String): Option[Recipe] = {
     contextWrapper.dbContext.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId))).headOption
   }

--- a/common/src/main/scala/com/gu/recipeasy/models/RecipePreparation.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/RecipePreparation.scala
@@ -1,0 +1,11 @@
+package com.gu.recipeasy.models
+
+import java.time.OffsetDateTime
+
+import com.gu.recipeasy.db.DB
+
+object RecipePreparation {
+  def selectRecipes(db: DB): List[Recipe] = {
+    db.getRecipes().filter(recipe => ((recipe.ingredientsLists.lists.size >= 5) && (recipe.status == New)))
+  }
+}

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -123,6 +123,12 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     Ok(views.html.statusdistribution(distribution))
   }
 
+  def prepareRecipesForCuration = Action { implicit request =>
+    val recipes: List[Recipe] = RecipePreparation.selectRecipes(db)
+    recipes.foreach(recipe => db.setOriginalRecipeStatus(recipe.id, Ready))
+    Ok(s"Operation Completed: updated ${recipes.size} recipes\n")
+  }
+
   // -------------------------------------------------------
 
   private def isShowCreation(): Boolean = {

--- a/ui/conf/routes
+++ b/ui/conf/routes
@@ -21,6 +21,7 @@ POST       /recipe/curate/:recipeId                                       contro
 GET        /admin                                                         controllers.Application.adminLandingPage
 GET        /admin/recent-activity                                         controllers.Application.recentActivity
 GET        /admin/status-distribution                                     controllers.Application.statusDistribution
+POST       /admin/prepare-recipes                                         controllers.Application.prepareRecipesForCuration
 
 # Auth
 GET        /login                                                         controllers.Login.login


### PR DESCRIPTION
This small change introduces an end-point with an idempotent operation that
is going to convert about 30 recipes from New to Ready.

The purpose is to prepare the database for another commit which is then going
to select them for curation and present them to users instead of recipes
in New status.

The commit after that will upgrade the preparation to include more
recipes (possibly recipes upgraded from the original partial parsing).