### PR TITLE
Scroll to new ingredients list after pressing 'l'

### DIFF
--- a/ui/public/javascript/editForm.js
+++ b/ui/public/javascript/editForm.js
@@ -114,6 +114,10 @@ Mousetrap.bind("l", function() {
     $(".ingredients-list:last-child .ingredient:first-child").remove()
     renumIngredients.call(this, $('.ingredients'))
     guessIngredient()
+
+    document.querySelector(".ingredients-list:last-child").scrollIntoView({
+        behavior: 'smooth'
+    });
 })
 
 Mousetrap.bind("m", function() {


### PR DESCRIPTION
At the moment there's no feedback after pressing the `l` key, which creates a new ingredients list. With this change it will scroll to the new list in the right-hand pane.