### PR TITLE
Updates in cuisines names

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -193,7 +193,7 @@ case class Tag(
 )
 
 object Tag {
-  val cuisines = Seq("African", "British", "Caribbean", "French", "Greek", "Indian", "Irish", "Italian", "Japanese", "Mexican", "Nordic", "North African", "Portuguese", "South American", "Spanish", "Thai and South East Asian")
+  val cuisines = Seq("African", "American", "Asian", "BBQ", "British", "Caribbean", "French", "Greek", "Indian", "Irish", "Italian", "Japanese", "Lebanese", "Mexican", "Nordic", "North African", "Portuguese", "South American", "Spanish", "Thai")
   val category = Seq("Baking", "Barbecue", "Breakfast", "Budget", "Canapes", "Dessert", "Dinner party", "Drinks and cockails", "Healthy eating", "Lunch", "Main course", "Picnic", "Sides", "Snacks", "Starters")
   val holidays = Seq("Baisakhi", "Christmas", "Diwali", "Easter", "Eid", "Halloween", "Hanukkah", "Passover", "Thanksgiving")
   val dietary = Seq("Low sugar", "Low fat", "High fibre", "Nut free", "Gluten free", "Dairy free", "Egg free", "Vegetarian", "Vegan")


### PR DESCRIPTION
Before:

![screen shot 2016-11-28 at 11 52 34](https://cloud.githubusercontent.com/assets/6035518/20667471/50447074-b561-11e6-924a-c0107bab4957.png)


After:

![screen shot 2016-11-28 at 11 52 18](https://cloud.githubusercontent.com/assets/6035518/20667470/4b65e7fe-b561-11e6-9909-1e47e214b254.png)


