### PR TITLE
Last trivial migration

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/RecipeReadiness.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/RecipeReadiness.scala
@@ -3,11 +3,11 @@ package com.gu.recipeasy.models
 import com.gu.recipeasy.db.DB
 
 object RecipeReadiness {
-  def selectRecipes(db: DB): List[Recipe] = {
-    db.getRecipes().filter(recipe => ((recipe.ingredientsLists.lists.size >= 2) && (recipe.status == New)))
+  def selectNewRecipesWithNonEmptyIngredientLists(db: DB): List[Recipe] = {
+    db.getRecipes().filter(recipe => ((recipe.ingredientsLists.lists.size > 0) && (recipe.status == New)))
   }
   def updateRecipesReadiness(db: DB): Int = {
-    val recipes: List[Recipe] = selectRecipes(db)
+    val recipes: List[Recipe] = selectNewRecipesWithNonEmptyIngredientLists(db)
     recipes.foreach(recipe => db.setOriginalRecipeStatus(recipe.id, Ready))
     recipes.size
   }


### PR DESCRIPTION
1. Rename `selectRecipes`
2. Move the threashold to the minimum possible value. Last step of the trivial migration process