### PR TITLE
Disactivate the i-shortcut

### DIFF
--- a/ui/public/javascript/editForm.js
+++ b/ui/public/javascript/editForm.js
@@ -90,6 +90,7 @@ $( document ).ready(function() {
 })
 
 //KEYBOARD SHORT CUTS
+/*
 Mousetrap.bind("i", function() {
     //last ingredient in first ingredients list
     var ingredient = $(".ingredients").first().children(".ingredient").last()
@@ -100,6 +101,7 @@ Mousetrap.bind("i", function() {
     renumIngredients.call(this, $('.ingredients'))
     guessIngredient()
 })
+*/
 
 //try to parse a whole block
 Mousetrap.bind("l", function() {


### PR DESCRIPTION
The mention of the i-shortcut was already removed from the user interface, but the functionality was still active. This dis-activates it.