### PR TITLE
Cloud formation update with updated Guardian office IP addresses

### DIFF
--- a/cloudformation/app.yml
+++ b/cloudformation/app.yml
@@ -192,22 +192,6 @@ Resources:
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 220.244.211.244/30 # Sydney
-        - IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: 220.244.211.244/30 # Sydney
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: 125.253.8.136/29 # Sydney
-        - IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: 125.253.8.136/29 # Sydney
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
           CidrIp: 220.244.148.144/28 # Sydney
         - IpProtocol: tcp
           FromPort: 80

--- a/cloudformation/app.yml
+++ b/cloudformation/app.yml
@@ -168,43 +168,59 @@ Resources:
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 77.91.248.0/21
+          CidrIp: 77.91.248.0/21 # London office
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: 77.91.248.0/21
+          CidrIp: 77.91.248.0/21 # London office
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 74.113.160.155/32
+          CidrIp: 162.213.134.128/26 # NYC
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: 74.113.160.155/32
+          CidrIp: 162.213.134.128/26 # NYC
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 203.174.136.130/32
+          CidrIp: 199.76.32.0/26 # NYC
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: 203.174.136.130/32
+          CidrIp: 199.76.32.0/26 # NYC
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 202.177.218.67/32
+          CidrIp: 220.244.211.244/30 # Sydney
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: 202.177.218.67/32
+          CidrIp: 220.244.211.244/30 # Sydney
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 125.253.45.20/32
+          CidrIp: 125.253.8.136/29 # Sydney
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: 125.253.45.20/32
+          CidrIp: 125.253.8.136/29 # Sydney
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 220.244.148.144/28 # Sydney
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 220.244.148.144/28 # Sydney
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 125.253.8.144/28 # Sydney
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 125.253.8.144/28 # Sydney
       SecurityGroupEgress:
         - IpProtocol: tcp
           FromPort: 9000


### PR DESCRIPTION
```
77.91.248.0/21       # London
162.213.134.128/26   # NYC
199.76.32.0/26       # NYC
220.244.211.244/30   # Sydney
125.253.8.136/29     # Sydney
220.244.148.144/28   # Sydney
125.253.8.144/28     # Sydney
```

As per: https://github.com/guardian/ophan-data-lake/blob/8ac770c0c5746a722c25c24f1a6898e57950fdb1/cloudformation/presto.template.yaml#L281-L289