### PR TITLE
Recipeasy - implementing Caching on progress bar queries.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ val commonSettings = Seq(
   scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings"),
   scalacOptions in doc in Compile := Nil,
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "2.2.6" % Test,
     "io.circe" %% "circe-core" % CirceVersion,
     "io.circe" %% "circe-generic" % CirceVersion,
     "io.circe" %% "circe-parser" % CirceVersion,
@@ -18,7 +17,10 @@ val commonSettings = Seq(
     "io.getquill" %% "quill-jdbc" % "0.9.0",
     "commons-codec" % "commons-codec" % "1.10",
     "com.github.cb372" %% "automagic" % "0.1",
-    "com.amazonaws" % "amazon-kinesis-client" % "1.6.2"
+    "com.github.ben-manes.caffeine" % "caffeine" % "2.3.5",
+    "com.google.code.findbugs" % "jsr305" % "3.0.1", // required to prevent Caffeine causing compile to fail given -Xfatal-warnings flag.
+    "com.amazonaws" % "amazon-kinesis-client" % "1.6.2",
+    "org.scalatest" %% "scalatest" % "2.2.6" % Test
   )
 )
 

--- a/common/src/main/scala/com/gu/recipeasy/Caches.scala
+++ b/common/src/main/scala/com/gu/recipeasy/Caches.scala
@@ -1,0 +1,18 @@
+package com.gu.recipeasy
+
+import java.util.concurrent.TimeUnit
+import com.github.benmanes.caffeine.cache.Caffeine
+
+class Cache[T <: Object, R <: Object](maximumSize: Long, expireAfterHours: Long) {
+
+  private lazy val cache = Caffeine.newBuilder()
+    .maximumSize(maximumSize)
+    .expireAfterWrite(expireAfterHours, TimeUnit.HOURS)
+    .build[T, R]()
+
+  def get(key: T): Option[R] = Option(cache.getIfPresent(key))
+  def put(key: T, value: R) { cache.put(key, value) }
+}
+
+object ProgressCache extends Cache[String, java.lang.Double](maximumSize = 2, expireAfterHours = 1)
+

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -5,12 +5,14 @@ import java.time.{ OffsetDateTime, ZoneOffset }
 import java.util.Date
 
 import com.gu.recipeas.db.ContextWrapper
+import com.gu.recipeasy.ProgressCache
 import com.gu.recipeasy.models._
 import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.syntax._
 import io.circe.parser._
 import org.postgresql.util.PGobject
+import scala.collection.JavaConverters._
 
 import scala.reflect.ClassTag
 
@@ -183,11 +185,27 @@ class DB(contextWrapper: ContextWrapper) {
   }
 
   def curationCompletionRatio(): Double = {
-    (countRecipesInGivenStatus(Pending) + countRecipesInGivenStatus(Curated)) / countRecipes()
+    val Key = "curationCompletionRatio"
+
+    val ratio = ProgressCache.get(Key).getOrElse {
+      val result: java.lang.Double = ((countRecipesInGivenStatus(Pending) + countRecipesInGivenStatus(Curated)) / countRecipes()).toDouble
+      ProgressCache.put(Key, result)
+      result
+    }
+
+    ratio
   }
 
   def verificationCompletionRatio(): Double = {
-    (countRecipesInGivenStatus(Pending) + countRecipesInGivenStatus(Curated) + countRecipesInGivenStatus(Verified) + countRecipesInGivenStatus(Finalised)) / countRecipes()
+    val Key = "verificationCompletionRatio"
+
+    val ratio = ProgressCache.get(Key).getOrElse {
+      val result: java.lang.Double = ((countRecipesInGivenStatus(Pending) + countRecipesInGivenStatus(Curated) + countRecipesInGivenStatus(Verified) + countRecipesInGivenStatus(Finalised)) / countRecipes()).toDouble
+      ProgressCache.put(Key, result)
+      result
+    }
+
+    ratio
   }
 
   // ---------------------------------------------

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -19,8 +19,8 @@ import models.CuratedRecipeForm._
 class Application(override val wsClient: WSClient, override val conf: Configuration, db: DB, val messagesApi: MessagesApi) extends Controller with AuthActions with I18nSupport with StrictLogging {
 
   def index = AuthAction { implicit request =>
-    val curationIndex: Double = (db.curationCompletionRatio() * 100) // expected to be between 0 and 100
-    val verificationIndex: Double = (db.verificationCompletionRatio() * 100) // expected to be between 0 and 100
+    val curationIndex: Double = db.curationCompletionRatio() * 100 // expected to be between 0 and 100
+    val verificationIndex: Double = db.verificationCompletionRatio() * 100 // expected to be between 0 and 100
     Ok(views.html.app("Recipeasy", curationIndex, verificationIndex))
   }
 


### PR DESCRIPTION
These are now cached for 1 hour and evicted after. The cache has a maximum size of 2.