### PR TITLE
Correction in curateRecipe

### DIFF
--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -60,7 +60,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
         if (recipe.status == Ready || recipe.status == Pending) {
           db.setOriginalRecipeStatus(recipe.id, Pending)
           db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, "Access Curation Page"))
-          curatedRecipedEditor(Some(recipe), editable = true)
+          curatedRecipedEditor(db.getOriginalRecipe(id), editable = true)
         } else {
           Redirect(routes.Application.viewRecipe(recipe.id)) // redirection to read only
         }


### PR DESCRIPTION
This corrects a little bug that was introduced yesterday.

In the old version, the instruction
```
curatedRecipedEditor(Some(recipe), editable = true)
```
passes to `curatedRecipedEditor` a recipe that carries the `Ready` status, despite the status
having been updated by a previous instruction:
```
db.setOriginalRecipeStatus(recipe.id, Pending)
```

In the new version the instruction:
```
curatedRecipedEditor(db.getOriginalRecipe(id), editable = true)
```
passes to `curatedRecipedEditor` a recipe freshly read from the database and therefore carrying the most
up to date status.