### PR TITLE
Better User Events Operation Types

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
@@ -6,9 +6,24 @@ import java.time.OffsetDateTime
 
 sealed trait OperationType
 
-case object Curation extends OperationType
-case object Verification extends OperationType
-case object Confirmation extends OperationType
+case object Curation extends OperationType {
+  override def toString: String = "Curation"
+}
+case object Verification extends OperationType {
+  override def toString: String = "Verification"
+}
+case object Confirmation extends OperationType {
+  override def toString: String = "Confirmation"
+}
+case object AccessRecipeReadOnlyPage extends OperationType {
+  override def toString: String = "Recipe Read Only Page"
+}
+case object AccessRecipeCurationPage extends OperationType {
+  override def toString: String = "Access Curation Page"
+}
+case object AccessRecipeVerificationPage extends OperationType {
+  override def toString: String = "Access Verification Page"
+}
 
 case class UserEvent(
   user_email: String,

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -32,7 +32,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
 
   def viewRecipe(id: String) = AuthAction { implicit request =>
     val recipe = db.getOriginalRecipe(id)
-    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, "Recipe Read Only Page"))
+    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeReadOnlyPage.toString))
     curatedRecipedEditor(recipe, editable = false)
   }
 
@@ -59,7 +59,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
       case Some(recipe) => {
         if (recipe.status == Ready || recipe.status == Pending) {
           db.setOriginalRecipeStatus(recipe.id, Pending)
-          db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, "Access Curation Page"))
+          db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeCurationPage.toString))
           curatedRecipedEditor(db.getOriginalRecipe(id), editable = true)
         } else {
           Redirect(routes.Application.viewRecipe(recipe.id)) // redirection to read only
@@ -73,7 +73,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     val recipe = db.getOriginalRecipe(id)
     // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
     // But we need to record the fact that the recipe is being verified.
-    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, "Access Verification Page"))
+    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeVerificationPage.toString))
     curatedRecipedEditor(recipe, editable = true)
   }
 


### PR DESCRIPTION
This change:

1. Introduces three new user events `OperationType`s.
2. Override their `toString` method to be (backward) compatible with the strings that have been
   used so far to record user events.