### PR TITLE
clears title in new ingredients list

### DIFF
--- a/ui/public/javascript/editForm.js
+++ b/ui/public/javascript/editForm.js
@@ -166,6 +166,7 @@ function createNewIngredientList(){
     newList.find(".ingredient").not(":first").each(function(){
         $(this).remove()
     })
+    newList.find("input").val("").end()
 }
 
 function createNewStep(elemBefore, text){


### PR DESCRIPTION
I saw that when you create a new ingredient list and there is already a list with a title, it copies over the title to the new list. e.g. with recipe fb093689898b1a94b5af83b82cc049c3

The title text is taken from the element's value - so if you manually type in a title for list 1 and then create a new list (list 2) the title will not be copied over. 

The code that cleans the title [was removed](https://github.com/guardian/recipeasy/pull/83/files#diff-29f61e2a4b35463f2ad6d6f17a06ebafL157) in #83 but from the PR I do not fully understand what the bug was and if this will reintroduce it, @shtukas hopefully you can help! 

NOW
![no title](https://cloud.githubusercontent.com/assets/8484757/20923340/dd29f66a-bba3-11e6-86b4-95f6c948c943.gif)

BEFORE
![wrong title](https://cloud.githubusercontent.com/assets/8484757/20923346/e5b40bfe-bba3-11e6-9d6b-5723a22a4c2d.gif)


