### PR TITLE
Cuisines correctly reported after curation

### DIFF
--- a/ui/app/com/gu/recipeasy/models/TagHelper.scala
+++ b/ui/app/com/gu/recipeasy/models/TagHelper.scala
@@ -14,7 +14,7 @@ object TagHelper {
   object FormTags {
     def apply(tags: Tags): FormTags = {
       FormTags(
-        cuisine = tags.list.collect { case t if t.category == "cuisine" => t.name },
+        cuisine = tags.list.collect { case t if t.category == "cuisines" => t.name },
         category = tags.list.collect { case t if t.category == "category" => t.name },
         holiday = tags.list.collect { case t if t.category == "holiday" => t.name },
         dietary = tags.list.collect { case t if t.category == "dietary" => t.name }


### PR DESCRIPTION
This corrects a bug by which selected cuisines during curation were not shown on the read only recipe view or the verifications steps. They now show up correctly:

<img width="554" alt="screen shot 2016-12-08 at 21 13 00" src="https://cloud.githubusercontent.com/assets/6035518/21027996/22c029c2-bd8b-11e6-856f-28f1d267bbb3.png">



