### PR TITLE
Ingredients quantities atomic step change

### DIFF
--- a/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
+++ b/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
@@ -20,7 +20,7 @@
                 @b4.button('class -> "btn btn-default btn-sm button-remove ingredient__button-remove") { <i class="fa fa-times" aria-hidden="true"></i> }
             </div>
             <div class="flex small-children">
-                @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.25, 'min -> 0, 'placeholder -> "quantity")
+                @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
                 @b4.select(field("unit"), 'class -> "ingredient__detail ingredient__detail__unit form-control-sm", '_label -> "unit") { implicit values =>
                     @b4.selectOption("", "—")
                     <optgroup label="Weights"> @weights.map { i => @b4.selectOption(i.abbreviation, i.displayName) } </optgroup>
@@ -46,7 +46,7 @@
               @b4.button('class -> "btn btn-default btn-sm button-remove ingredient__button-remove") { <i class="fa fa-times" aria-hidden="true"></i> }
           </div>
           <div class="flex small-children">
-              @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.25, 'min -> 0, 'placeholder -> "quantity")
+              @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
               @b4.select(i("unit"), 'class -> "ingredient__detail ingredient__detail__unit form-control-sm", '_label -> "unit") { implicit values =>
                   @b4.selectOption("", "—")
                   <optgroup label="Weights"> @weights.map { i => @b4.selectOption(i.abbreviation, i.displayName) } </optgroup>


### PR DESCRIPTION
This change now allow more natural fractions to be entered (in numeric form). For instance `0.20` and `0.25` can coexist as quantities in the same ingredient list.

<img width="498" alt="screen shot 2016-12-09 at 07 26 16" src="https://cloud.githubusercontent.com/assets/6035518/21041096/ccc78550-bde0-11e6-8741-32c90037025c.png">

