### PR TITLE
Add the ability to export recipes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,8 @@ lazy val common = (project in file("common"))
   .settings(flywaySettings)
   .settings(Seq(
       libraryDependencies ++= Seq(
-          "org.jsoup" % "jsoup" % "1.9.2"
+          "org.jsoup" % "jsoup" % "1.9.2",
+          "com.gu" %% "content-api-client" % "10.17"
       )
   ))
 
@@ -77,7 +78,6 @@ lazy val etl = (project in file("etl"))
   .dependsOn(common)
   .settings(Seq(
       libraryDependencies ++= Seq(
-        "com.gu" %% "content-api-client" % "10.5",
         "org.jsoup" % "jsoup" % "1.9.2",
         "org.typelevel" %% "cats-core" % "0.6.1"
       ),

--- a/common/src/main/scala/com/gu/recipeasy/db/ContextWrapper.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/ContextWrapper.scala
@@ -1,4 +1,4 @@
-package com.gu.recipeas.db
+package com.gu.recipeasy.db
 
 import com.typesafe.config.{ Config => TypesafeConfig }
 import io.getquill.{ ImplicitQuery, JdbcContext, PostgresDialect, SnakeCase }

--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -4,7 +4,6 @@ import java.sql.Types
 import java.time.{ OffsetDateTime, ZoneOffset }
 import java.util.Date
 
-import com.gu.recipeas.db.ContextWrapper
 import com.gu.recipeasy.ProgressCache
 import com.gu.recipeasy.models._
 import io.circe.Json

--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -19,7 +19,7 @@ import scala.language.higherKinds
 import java.time.OffsetDateTime
 
 import org.apache.commons.codec.digest.DigestUtils._
-import com.gu.recipeas.db.ContextWrapper
+import com.gu.recipeasy.db.ContextWrapper
 import com.typesafe.config.ConfigFactory
 
 case class Progress(pagesProcessed: Int, articlesProcessed: Int, recipesFound: Int, articlesWithNoRecipes: List[String]) {

--- a/ui/app/com/gu/recipeasy/AppComponents.scala
+++ b/ui/app/com/gu/recipeasy/AppComponents.scala
@@ -2,20 +2,25 @@ import com.amazonaws.auth.{ AWSCredentialsProviderChain, InstanceProfileCredenti
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.{ Region, Regions }
 import com.gu.cm.{ ConfigurationLoader, Identity }
-import com.gu.recipeas.db.ContextWrapper
+import com.gu.recipeasy.db.DB
+import com.gu.recipeasy.db.ContextWrapper
 import com.gu.recipeasy.{ KinesisAppenderConfig, LogStash }
-import play.filters.csrf.CSRFComponents
+
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.BuiltInComponentsFromContext
 import play.api.routing.Router
 import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, MessagesApi }
-import controllers._
-import com.gu.recipeasy.db.DB
+import play.filters.csrf.CSRFComponents
 import play.filters.gzip.GzipFilterComponents
-import router.Routes
+
 import scala.concurrent.Future
 import schedule.DBHouseKeepingScheduler
+
+import controllers._
+import services._
+import router.Routes
+import services.PublisherConfig
 
 class AppComponents(context: Context)
     extends BuiltInComponentsFromContext(context)
@@ -32,7 +37,8 @@ class AppComponents(context: Context)
     new ProfileCredentialsProvider("capi"),
     new InstanceProfileCredentialsProvider()
   )
-  val region = Region getRegion Regions.fromName(configuration.getString("aws.region").getOrElse(Regions.EU_WEST_1.getName))
+
+  val region = Region.getRegion(Regions.fromName(configuration.getString("aws.region").getOrElse(Regions.EU_WEST_1.getName)))
 
   val appenderConfig = KinesisAppenderConfig(configuration.getString("aws.logging.kinesisStreamName").getOrElse(""), credentialsProvider, region)
 
@@ -48,10 +54,13 @@ class AppComponents(context: Context)
   val messagesApi: MessagesApi = new DefaultMessagesApi(environment, configuration, new DefaultLangs(configuration))
   val dbHouseKeepingScheduler = new DBHouseKeepingScheduler(db)
 
+  val teleporter = new Teleporter(wsClient)
+
   val healthcheckController = new Healthcheck
   val applicationController = new Application(wsClient, configuration, db, messagesApi)
+  val publisherController = new Publisher(wsClient, configuration, PublisherConfig(configuration, region, identity.stage), db, teleporter)
   val loginController = new Login(wsClient, configuration)
   val assets = new Assets(httpErrorHandler)
-  val router: Router = new Routes(httpErrorHandler, healthcheckController, applicationController, loginController, assets)
+  val router: Router = new Routes(httpErrorHandler, healthcheckController, applicationController, publisherController, loginController, assets)
 
 }

--- a/ui/app/com/gu/recipeasy/controllers/Publisher.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Publisher.scala
@@ -1,0 +1,57 @@
+package controllers
+
+import com.gu.recipeasy.auth.AuthActions
+import com.gu.recipeasy.db.DB
+import com.gu.recipeasy.models.{ Recipe, CuratedRecipe }
+import com.gu.contentatom.thrift.{ ContentAtomEvent, EventType }
+import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{ AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType }
+
+import java.time.OffsetDateTime
+
+import services.{ AtomPublisher, PublisherConfig, Teleporter }
+
+import play.api.Configuration
+import play.api.libs.ws.WSClient
+import play.api.mvc.{ Action, Controller }
+
+import scala.util.{ Failure, Success, Try }
+import scala.concurrent.Future
+
+class Publisher(override val wsClient: WSClient, override val conf: Configuration, config: PublisherConfig, db: DB, teleporter: Teleporter) extends Controller with AuthActions {
+
+  def publish(id: String) = AuthAction.async { implicit request =>
+    db.getOriginalRecipe(id) match {
+
+      case Some(recipe) =>
+        db.getCuratedRecipeByRecipeId(recipe.id).map(CuratedRecipe.fromCuratedRecipeDB) match {
+          case Some(curatedRecipe) =>
+
+            import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+            teleporter.getInternalComposerCode(recipe.articleId).map { internalComposerCode =>
+              val result = send(internalComposerCode, recipe, curatedRecipe)(config)
+              result match {
+                case Success(_) => Ok(s"Publishing content atom")
+                case Failure(error) => Ok(s"Failed to publish content atom: ${error.getMessage}")
+              }
+            }
+
+          case None => Future.successful(NotFound)
+        }
+      case None => Future.successful(NotFound)
+    }
+  }
+
+  private def send(internalComposerCode: String, recipe: Recipe, curatedRecipe: CuratedRecipe)(config: PublisherConfig) = {
+
+    val atomEvents: (AuxiliaryAtomEvent, ContentAtomEvent) = {
+      val contentAtom = CuratedRecipe.toAtom(recipe, curatedRecipe)
+      val auxiliaryAtomEvent = AuxiliaryAtomEvent(internalComposerCode, eventType = AuxiliaryAtomEventType.Add, Seq(AuxiliaryAtom(contentAtom.id, "recipe")))
+      val contentAtomEvent = ContentAtomEvent(contentAtom, EventType.Update, eventCreationTime = OffsetDateTime.now.toInstant.toEpochMilli)
+      (auxiliaryAtomEvent, contentAtomEvent)
+    }
+
+    AtomPublisher.send(atomEvents)(config)
+  }
+
+}

--- a/ui/app/com/gu/recipeasy/services/AtomPublisher.scala
+++ b/ui/app/com/gu/recipeasy/services/AtomPublisher.scala
@@ -1,0 +1,53 @@
+package services
+
+import com.amazonaws.services.kinesis.model.PutRecordRequest
+import com.amazonaws.services.kinesis.model.PutRecordResult
+import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.AuxiliaryAtomEvent
+import com.gu.contentatom.thrift.ContentAtomEvent
+
+import scala.util.Try
+
+object AtomPublisher {
+
+  private object composerAuxiliaryAtomIntegration {
+
+    def send(event: AuxiliaryAtomEvent)(config: PublisherConfig): Try[PutRecordResult] = {
+      val data = ThriftSerializer.serializeEvent(event)
+      val record = new PutRecordRequest()
+        .withData(data)
+        .withStreamName(config.auxiliaryAtomConfig.streamName)
+        .withPartitionKey(event.contentId)
+
+      Try(config.auxiliaryAtomConfig.kinesisClient.putRecord(record))
+    }
+  }
+
+  private object porterAtomIntegration {
+
+    def send(event: ContentAtomEvent)(config: PublisherConfig): Try[PutRecordResult] = {
+      val data = ThriftSerializer.serializeEvent(event)
+      val record = new PutRecordRequest()
+        .withData(data)
+        .withStreamName(config.contentAtomConfig.streamName)
+        .withPartitionKey(event.atom.atomType.name)
+
+      Try(config.contentAtomConfig.kinesisClient.putRecord(record))
+    }
+
+  }
+
+  /**
+   * Sends events to Porter and Composer to create new Content and Auxiliary atoms respectively.
+   * @param atomEvents
+   * @param config
+   */
+  def send(atomEvents: (AuxiliaryAtomEvent, ContentAtomEvent))(config: PublisherConfig): Try[List[PutRecordResult]] = {
+    val auxiliaryAtomEvent = atomEvents._1
+    val contentAtomEvent = atomEvents._2
+    for {
+      composerPutResult <- composerAuxiliaryAtomIntegration.send(auxiliaryAtomEvent)(config)
+      porterPutResult <- porterAtomIntegration.send(contentAtomEvent)(config)
+    } yield List(composerPutResult, porterPutResult)
+  }
+
+}

--- a/ui/app/com/gu/recipeasy/services/PublisherConfig.scala
+++ b/ui/app/com/gu/recipeasy/services/PublisherConfig.scala
@@ -1,0 +1,64 @@
+package services
+
+import java.io.File
+
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider.Builder
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.{ Region, Regions }
+import com.amazonaws.services.kinesis.AmazonKinesisClient
+import com.gu.contentapi.client.GuardianContentClient
+import play.api.Configuration
+
+import scala.util.Try
+
+case class ContentAtomConfig(streamName: String, stsRoleArn: String, kinesisClient: AmazonKinesisClient)
+case class AuxiliaryAtomConfig(streamName: String, stsRoleArn: String, kinesisClient: AmazonKinesisClient)
+case class PublisherConfig(contentAtomConfig: ContentAtomConfig, auxiliaryAtomConfig: AuxiliaryAtomConfig)
+
+object PublisherConfig {
+
+  def apply(config: Configuration, region: Region, stage: String): PublisherConfig = {
+
+    val contentAtomStreamName = s"content-atom-events-live-${stage.toUpperCase}"
+
+    val contentAtomStsRoleArn = config.getString("aws.atom.content.stsRoleArn").getOrElse("")
+
+    val contentAtomConfig = ContentAtomConfig(
+      contentAtomStreamName,
+      contentAtomStsRoleArn,
+      kinesisClient = {
+      val kinesisCredentialsProvider = new AWSCredentialsProviderChain(
+        new ProfileCredentialsProvider("composer"),
+        new Builder(contentAtomStsRoleArn, "contentAtom").build()
+      )
+
+      val kinesisClient = new AmazonKinesisClient(kinesisCredentialsProvider)
+      kinesisClient.setRegion(region)
+      kinesisClient
+    }
+    )
+
+    val auxiliaryAtomStreamName = s"auxiliary-atom-feed-${stage.toUpperCase}"
+
+    val auxiliaryAtomStsRoleArn = config.getString("aws.atom.auxiliary.stsRoleArn").getOrElse("")
+
+    val auxiliaryAtomConfig = AuxiliaryAtomConfig(
+      auxiliaryAtomStreamName,
+      auxiliaryAtomStsRoleArn,
+      kinesisClient = {
+      val kinesisCredentialsProvider = new AWSCredentialsProviderChain(
+        new ProfileCredentialsProvider("composer"),
+        new Builder(auxiliaryAtomStsRoleArn, "auxiliaryAtom").build()
+      )
+
+      val kinesisClient = new AmazonKinesisClient(kinesisCredentialsProvider)
+      kinesisClient.setRegion(region)
+      kinesisClient
+    }
+    )
+
+    PublisherConfig(contentAtomConfig, auxiliaryAtomConfig)
+  }
+
+}

--- a/ui/app/com/gu/recipeasy/services/Teleporter.scala
+++ b/ui/app/com/gu/recipeasy/services/Teleporter.scala
@@ -1,0 +1,22 @@
+package services
+
+import java.util.concurrent.Executors
+import play.api.libs.ws.WSClient
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Await }
+import scala.util.Try
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class Teleporter(ws: WSClient) {
+
+  def getInternalComposerCode(path: String)(implicit ec: ExecutionContext): Future[String] = {
+
+    val teleporterURI = s"https://teleporter.gutools.co.uk/api/pages?uri=https://www.theguardian.com/$path"
+    ws.url(teleporterURI).get map { response =>
+      (response.json \ "identifiers" \ "composerId").as[String]
+    }
+  }
+
+}

--- a/ui/app/com/gu/recipeasy/services/ThriftSerializer.scala
+++ b/ui/app/com/gu/recipeasy/services/ThriftSerializer.scala
@@ -1,0 +1,22 @@
+package services
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+
+import com.twitter.scrooge.ThriftStruct
+import org.apache.thrift.protocol.TCompactProtocol
+import org.apache.thrift.transport.TIOStreamTransport
+
+object ThriftSerializer {
+
+  val CompressionTypeNone = 0x00.toByte
+
+  def serializeEvent[T <: ThriftStruct](event: T): ByteBuffer = {
+    val out = new ByteArrayOutputStream()
+    val transport = new TIOStreamTransport(out)
+    val protocol = new TCompactProtocol(transport)
+    event.write(protocol)
+    ByteBuffer.wrap(CompressionTypeNone +: out.toByteArray)
+  }
+
+}

--- a/ui/conf/application.conf
+++ b/ui/conf/application.conf
@@ -29,4 +29,6 @@ db {
 aws {
   region="eu-west-1"
   logging.kinesisStreamName=""
+  atom.content.stsRoleArn=""
+  atom.auxiliary.stsRoleArn=""
 }

--- a/ui/conf/routes
+++ b/ui/conf/routes
@@ -17,6 +17,7 @@ GET        /recipe/:recipeId                                              contro
 
 # Curation
 POST       /recipe/curate/:recipeId                                       controllers.Application.postCuratedRecipe(recipeId)
+POST       /recipe/publish/:recipeId                                      controllers.Publisher.publish(recipeId)
 
 # Admin & Instrospection
 GET        /admin                                                         controllers.Application.adminLandingPage

--- a/ui/test/com/gu/recipeasy/services/TeleporterSpec.scala
+++ b/ui/test/com/gu/recipeasy/services/TeleporterSpec.scala
@@ -1,0 +1,23 @@
+package services
+
+import org.scalatest.{ FlatSpec, Matchers }
+import play.api.test.WsTestClient.withClient
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class TeleporterSpec extends FlatSpec with Matchers {
+
+  it should "return correctly the composer code of a published article" in {
+    withClient { client =>
+
+      import scala.concurrent.ExecutionContext.Implicits.global
+
+      val teleporter = new Teleporter(client)
+      val code = teleporter.getInternalComposerCode("info/developer-blog/2016/nov/29/the-guardian-has-moved-to-https")
+      val result = Await.result(code, 30.seconds)
+      result should be("57e2852fe4b05d653ca5f3d6")
+    }
+  }
+
+}


### PR DESCRIPTION
The associated changes add the ability to export to content API a curated recipe through a new endpoint. The process is the following:

- Retrieve a curated recipe from a `recipe id`
- Retrieve a flexible id using `teleporter` api
- Create an atom model recipe from curated recipe
- Publish atom and update to the original article.

The new endpoint only return a simple text response has I have not yet defined a workflow.
Things to decide are:
- Should be `exported` a new status in the `DB` so we could easily monitor how much recipes we exported?
- Should we allow user to `export` or simply an admin task and export in batch?

 

 