### PR TITLE
Remove bug preventing holidays information to be shown at verification step

### DIFF
--- a/ui/app/com/gu/recipeasy/models/TagHelper.scala
+++ b/ui/app/com/gu/recipeasy/models/TagHelper.scala
@@ -16,7 +16,7 @@ object TagHelper {
       FormTags(
         cuisine = tags.list.collect { case t if t.category == "cuisines" => t.name },
         category = tags.list.collect { case t if t.category == "category" => t.name },
-        holiday = tags.list.collect { case t if t.category == "holiday" => t.name },
+        holiday = tags.list.collect { case t if t.category == "holidays" => t.name },
         dietary = tags.list.collect { case t if t.category == "dietary" => t.name }
       )
     }


### PR DESCRIPTION
This corrects a bug related to the reporting of holidays at verification step. 

A bug which should have been fixed together with this one: https://github.com/guardian/recipeasy/commit/5c1033a0f34334e92bf1b6d1398edc7bbfab188e but wasn't corrected because holidays handling was incorrectly scheduled to be decommissioned.