### PR TITLE
Allow to publish to Content API on GET

### DIFF
--- a/ui/conf/routes
+++ b/ui/conf/routes
@@ -17,7 +17,7 @@ GET        /recipe/:recipeId                                              contro
 
 # Curation
 POST       /recipe/curate/:recipeId                                       controllers.Application.postCuratedRecipe(recipeId)
-POST       /recipe/publish/:recipeId                                      controllers.Publisher.publish(recipeId)
+GET        /recipe/publish/:recipeId                                      controllers.Publisher.publish(recipeId)
 
 # Admin & Instrospection
 GET        /admin                                                         controllers.Application.adminLandingPage


### PR DESCRIPTION
I will put it back to `POST` and create a form later,  but I need to bypass the CSRF token filter for my first tests. 