### PR TITLE
Recipeasy - cloudformation permissions for kinesis do not need to be specified in this instance.

### DIFF
--- a/cloudformation/app.yml
+++ b/cloudformation/app.yml
@@ -215,22 +215,6 @@ Resources:
             - !Ref STSAuxiliaryAtomRoleToAssume
       Roles:
         - !Ref RootRole
-  FlexibleContentStreams:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: 'kinesis-atom-sender'
-      PolicyDocument:
-        Statement:
-         - Effect: Allow
-           Action:
-            - 'kinesis:PutRecord'
-            - 'kinesis:PutRecords'
-            - 'kinesis:DescribeStream'
-           Resource:
-            - !Sub 'arn:aws:kinesis:*:*:stream/flexible-content-*-${Stage}'
-            - !Sub 'arn:aws:kinesis:*:*:stream/auxiliary-atom-feed-${Stage}'
-      Roles:
-        - !Ref RootRole
   KinesisLogsSenderPolicy:
     Type: AWS::IAM::Policy
     Properties:


### PR DESCRIPTION
As we are accessing both kinesis streams via an STS role, the STS role is configured to define what actions we may take.