### PR TITLE
Introduce ranges for ingredient lists

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -71,6 +71,15 @@ object CuratedRecipe {
     })
   }
 
+  def atomRangeFromOptionalBounds(maybeFrom: Option[Double], maybeTo: Option[Double]): Option[atom.Range] = {
+    for {
+      from <- maybeFrom
+      to <- maybeTo
+    } yield {
+      atom.Range((from * 100).toShort, (to * 100).toShort)
+    }
+  }
+
   def toAtom(r: Recipe, cr: CuratedRecipe): Atom = {
 
     val contentChangeDetails = ContentChangeDetails(
@@ -129,6 +138,7 @@ object CuratedRecipe {
               item = ingredient.item,
               comment = ingredient.comment,
               quantity = ingredient.quantity,
+              quantityRange = atomRangeFromOptionalBounds(ingredient.quantityRangeFrom, ingredient.quantityRangeTo),
               unit = ingredient.unit.map(_.abbreviation)
             ))
         )),

--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipeTypes.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipeTypes.scala
@@ -48,10 +48,20 @@ case class DetailedIngredientsLists(lists: Seq[DetailedIngredientsList])
 object DetailedIngredientsLists {
   def fromIngredientsLists(ingredients: IngredientsLists): DetailedIngredientsLists = {
     new DetailedIngredientsLists(lists =
-      ingredients.lists.map(r => new DetailedIngredientsList(r.title, rawToDetailedIngredients(r.ingredients))))
+      ingredients.lists.map(r => DetailedIngredientsList(r.title, rawToDetailedIngredients(r.ingredients))))
   }
   private def rawToDetailedIngredients(ingredients: Seq[String]): Seq[DetailedIngredient] = {
-    ingredients.map(i => new DetailedIngredient(None, None, "", None, i))
+    ingredients.map { i =>
+      DetailedIngredient(
+        quantity = None,
+        quantityRangeFrom = None,
+        quantityRangeTo = None,
+        unit = None,
+        item = "",
+        comment = None,
+        raw = i
+      )
+    }
   }
 }
 
@@ -62,6 +72,8 @@ case class DetailedIngredientsList(
 
 case class DetailedIngredient(
   quantity: Option[Double],
+  quantityRangeFrom: Option[Double],
+  quantityRangeTo: Option[Double],
   unit: Option[CookingUnit],
   item: String,
   comment: Option[String],

--- a/common/src/main/scala/com/gu/recipeasy/models/RecipeReadiness.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/RecipeReadiness.scala
@@ -96,6 +96,8 @@ object RecipeReadiness {
           isl.title,
           isl.ingredients.map(string => DetailedIngredient(
             quantity = Some(1.toDouble),
+            quantityRangeFrom = None,
+            quantityRangeTo = None,
             unit = None,
             item = string,
             comment = None,

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -263,6 +263,8 @@ object Application {
         "title" -> optional(nonEmptyText(maxLength = 200)),
         "ingredients" -> seq(mapping(
           "quantity" -> optional(of[Double]),
+          "quantityRangeFrom" -> optional(of[Double]),
+          "quantityRangeTo" -> optional(of[Double]),
           "unit" -> optional(text.transform[CookingUnit](CookingUnit.fromString(_).getOrElse(Handful), _.abbreviation)),
           "item" -> nonEmptyText(maxLength = 200),
           "comment" -> optional(text(maxLength = 200)),

--- a/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
+++ b/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
@@ -20,7 +20,15 @@
                 @b4.button('class -> "btn btn-default btn-sm button-remove ingredient__button-remove") { <i class="fa fa-times" aria-hidden="true"></i> }
             </div>
             <div class="flex small-children">
-                @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+                <div>
+                    single measurement:
+                    @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+                    range:
+                    <div class="flex">
+                        @b4.number(field("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
+                        @b4.number(field("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                    </div>
+                </div>
                 @b4.select(field("unit"), 'class -> "ingredient__detail ingredient__detail__unit form-control-sm", '_label -> "unit") { implicit values =>
                     @b4.selectOption("", "—")
                     <optgroup label="Weights"> @weights.map { i => @b4.selectOption(i.abbreviation, i.displayName) } </optgroup>
@@ -46,7 +54,15 @@
               @b4.button('class -> "btn btn-default btn-sm button-remove ingredient__button-remove") { <i class="fa fa-times" aria-hidden="true"></i> }
           </div>
           <div class="flex small-children">
-              @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+              <div>
+                  single measurement:
+                  @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+                  range:
+                  <div class="flex">
+                      @b4.number(i("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
+                      @b4.number(i("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                  </div>
+              </div>
               @b4.select(i("unit"), 'class -> "ingredient__detail ingredient__detail__unit form-control-sm", '_label -> "unit") { implicit values =>
                   @b4.selectOption("", "—")
                   <optgroup label="Weights"> @weights.map { i => @b4.selectOption(i.abbreviation, i.displayName) } </optgroup>


### PR DESCRIPTION
This change enable range description for each ingredient. For this

1. We change `case class DetailedIngredient`
2. Modify the User Interface with two additional fields for ingredients
3. Echo the range in the receipe atom where a Double to Short is performed.