### PR TITLE
Improvements in the display of the range

### DIFF
--- a/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
+++ b/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
@@ -19,14 +19,25 @@
                 @b4.text(field("raw"), 'class -> "ingredient__detail ingredient__detail__parsed-ingredient form-control-sm form-hidden font-weight-bold")
                 @b4.button('class -> "btn btn-default btn-sm button-remove ingredient__button-remove") { <i class="fa fa-times" aria-hidden="true"></i> }
             </div>
-            <div class="flex small-children">
+            <div class="flex small-children" style="align-items:flex-start">
                 <div>
-                    single measurement:
-                    @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
-                    range:
-                    <div class="flex">
-                        @b4.number(field("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
-                        @b4.number(field("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                    <div class="ingredient__single-measurement-field">
+                        @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+                    </div>
+                    <div class="ingredient__range-measurement-field">
+                        <div class="flex">
+                            @b4.number(field("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
+                            <div style="padding-right:10px;">–</div>
+                            @b4.number(field("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                        </div>
+                    </div>
+                    <div style="font-size:80%">
+                        <!--
+                            The checkbox input is two levels below the parent of
+                            class="ingredient__single-measurement-field" and class="ingredient__range-measurement-field"
+                            This is to match the code of editForm.js $("body").on("change", '.ingredient__measurement-toggle'
+                        -->
+                        <input type="checkbox" class="ingredient__measurement-toggle"> <span style="color:grey;">range</span>
                     </div>
                 </div>
                 @b4.select(field("unit"), 'class -> "ingredient__detail ingredient__detail__unit form-control-sm", '_label -> "unit") { implicit values =>
@@ -53,14 +64,25 @@
               @b4.text(i("raw"), 'class -> "ingredient__detail ingredient__detail__parsed-ingredient form-control-sm form-hidden")
               @b4.button('class -> "btn btn-default btn-sm button-remove ingredient__button-remove") { <i class="fa fa-times" aria-hidden="true"></i> }
           </div>
-          <div class="flex small-children">
+          <div class="flex small-children" style="align-items:flex-start">
               <div>
-                  single measurement:
-                  @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
-                  range:
-                  <div class="flex">
-                      @b4.number(i("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
-                      @b4.number(i("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                  <div class="ingredient__single-measurement-field">
+                      @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+                  </div>
+                  <div class="ingredient__range-measurement-field">
+                      <div class="flex">
+                          @b4.number(i("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-80 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
+                          <div style="padding-right:10px;">–</div>
+                          @b4.number(i("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-80 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                      </div>
+                  </div>
+                  <div style="font-size:80%">
+                        <!--
+                            The checkbox input is two levels below the parent of
+                            class="ingredient__single-measurement-field" and class="ingredient__range-measurement-field"
+                            This is to match the code of editForm.js $("body").on("change", '.ingredient__measurement-toggle'
+                        -->
+                      <input type="checkbox" class="ingredient__measurement-toggle"> <span style="color:grey;">range</span>
                   </div>
               </div>
               @b4.select(i("unit"), 'class -> "ingredient__detail ingredient__detail__unit form-control-sm", '_label -> "unit") { implicit values =>

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -143,7 +143,7 @@
                     @b4.number( curatedRecipeForm("serves")("quantity")("to"), 'class -> "form-control-sm")
                     &nbsp;&nbsp;&nbsp; (
                         <label class="field__serves__quantity__label">unit</label>
-                        @b4.select(curatedRecipeForm("serves")("unit"), Seq("" -> "_", "grams" -> "grams", "millilitres" -> "millilitres"), 'class -> "form-control-sm")
+                        @b4.select(curatedRecipeForm("serves")("unit"), Seq("" -> "", "grams" -> "grams", "millilitres" -> "millilitres"), 'class -> "form-control-sm")
                     &nbsp; )
                 </div>
             </div>

--- a/ui/public/javascript/editForm.js
+++ b/ui/public/javascript/editForm.js
@@ -324,6 +324,16 @@ $("body").on("click", 'input[name="serves.portionType"]', function(){
     })
 })
 
+$("body").on("change", '.ingredient__measurement-toggle', function(){
+    if($(this).prop("checked")==true){
+        $(this).parent().parent().find(".ingredient__single-measurement-field").hide()
+        $(this).parent().parent().find(".ingredient__range-measurement-field").show()
+    }else{
+        $(this).parent().parent().find(".ingredient__single-measurement-field").show()
+        $(this).parent().parent().find(".ingredient__range-measurement-field").hide()
+    }
+})
+
 var substringMatcher = function(strs) {
   return function findMatches(q, cb) {
     var matches, substringRegex;

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -725,6 +725,14 @@ img, video {
   margin-bottom: 1px;
   margin-right: 10px; }
 
+.ingredient__single-measurement-field {
+
+}
+
+.ingredient__range-measurement-field {
+  display:none
+}
+
 .form-hidden {
   background: transparent;
   border: none; }


### PR DESCRIPTION
In this commit we modify/improve the display of the ingredient list range. A checkbox
now controls the toggling of single measurement versus range measurement.

**Before**

![screen shot 2017-01-03 at 15 01 54](https://cloud.githubusercontent.com/assets/6035518/21611649/9fb98a6a-d1c5-11e6-929c-1023d903c796.png)

**After**

![screen shot 2017-01-03 at 15 02 34](https://cloud.githubusercontent.com/assets/6035518/21611670/b96117ee-d1c5-11e6-9b89-021c0165d179.png)


![screen shot 2017-01-03 at 15 02 49](https://cloud.githubusercontent.com/assets/6035518/21611677/bcebfb7c-d1c5-11e6-8a31-e7724438c9e8.png)



Also, removal of the "_" standing for "no unit" in the serve information.
