### PR TITLE
Stylistic updates in Ingredient item display

### DIFF
--- a/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
+++ b/ui/app/com/gu/recipeasy/views/helpers/multiIngredient.scala.html
@@ -22,13 +22,13 @@
             <div class="flex small-children" style="align-items:flex-start">
                 <div>
                     <div class="ingredient__single-measurement-field">
-                        @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+                        @b4.number(field("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-80 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "amount")
                     </div>
                     <div class="ingredient__range-measurement-field">
                         <div class="flex">
-                            @b4.number(field("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
-                            <div style="padding-right:10px;">–</div>
-                            @b4.number(field("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                            @b4.number(field("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-60 form-control-sm", 'style -> "margin-right: 2px;", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
+                            <div style="padding-right:2px;">–</div>
+                            @b4.number(field("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-60 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
                         </div>
                     </div>
                     <div style="font-size:80%">
@@ -67,13 +67,13 @@
           <div class="flex small-children" style="align-items:flex-start">
               <div>
                   <div class="ingredient__single-measurement-field">
-                      @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-100 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "quantity")
+                      @b4.number(i("quantity"), 'class -> "ingredient__detail ingredient__detail__quantity width-80 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "amount")
                   </div>
                   <div class="ingredient__range-measurement-field">
                       <div class="flex">
-                          @b4.number(i("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-80 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
-                          <div style="padding-right:10px;">–</div>
-                          @b4.number(i("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-80 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
+                          @b4.number(i("quantityRangeFrom"), 'class -> "ingredient__detail ingredient__detail__quantityRangeFrom width-60 form-control-sm", 'style -> "margin-right: 2px;", 'step -> 0.01, 'min -> 0, 'placeholder -> "from")
+                          <div style="padding-right:2px;">–</div>
+                          @b4.number(i("quantityRangeTo"), 'class -> "ingredient__detail ingredient__detail__quantityRangeTo width-60 form-control-sm", 'step -> 0.01, 'min -> 0, 'placeholder -> "to")
                       </div>
                   </div>
                   <div style="font-size:80%">

--- a/ui/public/stylesheets/main.css
+++ b/ui/public/stylesheets/main.css
@@ -693,6 +693,9 @@ img, video {
 .field__times .form-group {
   margin-right: 10px; }
 
+.width-60 {
+    width: 60px; }
+
 .width-80 {
   width: 80px; }
 


### PR DESCRIPTION
- width of a single measurement is now 80px
- placeholder for single measurement is now "amount"
- width for range component is now 60px
- the separator for range is now more tightly displayed.

![screen shot 2017-01-03 at 16 21 37](https://cloud.githubusercontent.com/assets/6035518/21614355/0cbec156-d1d1-11e6-9e51-b1d8e66f8225.png)
