### PR TITLE
In this commit

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
@@ -53,7 +53,7 @@ case class IngredientsList(
 )
 
 case class Serves(
-  from: Int,
-  to: Int
+  from: Double,
+  to: Double
 )
 

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -254,8 +254,8 @@ object Application {
       "serves" -> optional(mapping(
         "portionType" -> text.transform[PortionType](PortionType.fromString(_), _.toString),
         "quantity" -> mapping(
-          "from" -> number(min = 1),
-          "to" -> number(min = 1)
+          "from" -> of[Double],
+          "to" -> of[Double]
         )(Serves.apply)(Serves.unapply),
         "unit" -> optional(text)
       )(DetailedServes.apply)(DetailedServes.unapply)),

--- a/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
+++ b/ui/app/com/gu/recipeasy/models/CuratedRecipeForm.scala
@@ -29,6 +29,7 @@ object CuratedRecipeForm {
   }
 
   def fromForm(r: CuratedRecipeForm): CuratedRecipe = {
+
     val cuisineTags = getTags(r.tags.cuisine, "cuisine")
     val categoryTags = getTags(r.tags.category, "category")
     val holidayTags = getTags(r.tags.holiday, "holiday")
@@ -44,5 +45,7 @@ object CuratedRecipeForm {
       "tags" -> Tags(cuisineTags ++ categoryTags ++ holidayTags ++ dietaryTags),
       "images" -> Images(r.images)
     )
+
   }
+
 }

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -143,7 +143,12 @@
                     @b4.number( curatedRecipeForm("serves")("quantity")("to"), 'class -> "form-control-sm")
                     &nbsp;&nbsp;&nbsp; (
                         <label class="field__serves__quantity__label">unit</label>
-                        @b4.select(curatedRecipeForm("serves")("unit"), Seq("" -> "", "grams" -> "grams", "millilitres" -> "millilitres"), 'class -> "form-control-sm")
+                        <!--
+                            The strings that the unit are expected to be ( eg: "kilograms", "litres", "grams" and "millilitres" ),
+                            should match the values of the if conditionals in CuratedRecipe.scala atomServeQuantity and atomServeUnit
+                            The code will be made more robust in a later PR
+                        -->
+                        @b4.select(curatedRecipeForm("serves")("unit"), Seq("" -> "", "kilograms" -> "kg", "grams" -> "grams", "litres" -> "litres", "millilitres" -> "millilitres"), 'class -> "form-control-sm")
                     &nbsp; )
                 </div>
             </div>

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -138,9 +138,9 @@
             <div class="field__serves">
                 @b4.radio( curatedRecipeForm("serves")("portionType"),  options = Seq("ServesType" -> "Serves", "MakesType" -> "Makes", "QuantityType" -> "Quantity"), 'label -> "Portion")
                 <div class="flex field__serves__quantity">
-                    @b4.number( curatedRecipeForm("serves")("quantity")("from"), 'class -> "form-control-sm")
+                    @b4.number( curatedRecipeForm("serves")("quantity")("from"), 'class -> "form-control-sm", 'step -> 0.01, 'min -> 0)
                     <label class="field__serves__quantity__label">to</label>
-                    @b4.number( curatedRecipeForm("serves")("quantity")("to"), 'class -> "form-control-sm")
+                    @b4.number( curatedRecipeForm("serves")("quantity")("to"), 'class -> "form-control-sm", 'step -> 0.01, 'min -> 0)
                     &nbsp;&nbsp;&nbsp; (
                         <label class="field__serves__quantity__label">unit</label>
                         <!--

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -133,7 +133,7 @@
                 You can express:<br />
                 &nbsp;&nbsp;&nbsp;"Recipe <em>serves</em> 4 to 6 people" (Fill number range only)<br />
                 &nbsp;&nbsp;&nbsp;"Recipe <em>makes</em> 4 to 6 mince pies" (Fill number range only)<br />
-                &nbsp;&nbsp;&nbsp;"Recipe <em>makes quantity</em> 1.2 litres of juice" (Fill number range <b>and</b> unit, as "1200 to 1200 milliliters")<br />
+                &nbsp;&nbsp;&nbsp;"Recipe <em>makes quantity</em> 1.2 litres of juice" (Fill number range <b>and</b> unit, as "1.2 to 1.2 litres")<br />
             </div>
             <div class="field__serves">
                 @b4.radio( curatedRecipeForm("serves")("portionType"),  options = Seq("ServesType" -> "Serves", "MakesType" -> "Makes", "QuantityType" -> "Quantity"), 'label -> "Portion")


### PR DESCRIPTION
1. We allow the users to enter Servings quantities with two new units: litres and kilograms

2. We update the `toAtom(r: Recipe, cr: CuratedRecipe): Atom` function with an automatic conversion of
   litres and kilograms ( quantities and units ) to millilitres and grams

3. Note that the return value of atomServeQuantity is always Short
   therefore, in the case of millilitres and grams, we convert the Double to Short

The strings "litres", "kilograms", "millilitres" and "grams" will be made into a type in the next PR :)