### PR TITLE
Refactoring (removing hard coded strings, notably in Database Queries)

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
@@ -17,15 +17,15 @@ case class Recipe(
 
 case class Steps(steps: Seq[String])
 
-sealed trait RecipeStatus
+sealed trait RecipeStatus { val name: String }
 
-case object New extends RecipeStatus
-case object Ready extends RecipeStatus
-case object Pending extends RecipeStatus
-case object Curated extends RecipeStatus
-case object Verified extends RecipeStatus
-case object Finalised extends RecipeStatus
-case object Impossible extends RecipeStatus
+case object New extends RecipeStatus { val name = "New" }
+case object Ready extends RecipeStatus { val name = "Ready" }
+case object Pending extends RecipeStatus { val name = "Pending" }
+case object Curated extends RecipeStatus { val name = "Curated" }
+case object Verified extends RecipeStatus { val name = "Verified" }
+case object Finalised extends RecipeStatus { val name = "Finalised" }
+case object Impossible extends RecipeStatus { val name = "Impossible" }
 
 /*
 

--- a/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
@@ -33,15 +33,15 @@ object Leaderboard {
     }
 
     def eventsToCurationNumber(events: List[UserEventDB]): Int = {
-      events.filter(event => event.operation_type == Curation.toString).size
+      events.filter(event => event.operation_type == Curation.name).size
     }
 
     def eventsToVerificationNumber(events: List[UserEventDB]): Int = {
-      events.filter(event => event.operation_type == Verification.toString).size
+      events.filter(event => event.operation_type == Verification.name).size
     }
 
     def eventsToConfirmationNumber(events: List[UserEventDB]): Int = {
-      events.filter(event => event.operation_type == Confirmation.toString).size
+      events.filter(event => event.operation_type == Confirmation.name).size
     }
 
     events.map(event => event.user_email).distinct.map { email =>

--- a/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
@@ -4,25 +4,25 @@ import automagic._
 import java.util.Calendar
 import java.time.OffsetDateTime
 
-sealed trait OperationType
+sealed trait OperationType { val name: String }
 
 case object Curation extends OperationType {
-  override def toString: String = "Curation"
+  val name = "Curation"
 }
 case object Verification extends OperationType {
-  override def toString: String = "Verification"
+  val name = "Verification"
 }
 case object Confirmation extends OperationType {
-  override def toString: String = "Confirmation"
+  val name = "Confirmation"
 }
 case object AccessRecipeReadOnlyPage extends OperationType {
-  override def toString: String = "Recipe Read Only Page"
+  val name = "Recipe Read Only Page"
 }
 case object AccessRecipeCurationPage extends OperationType {
-  override def toString: String = "Access Curation Page"
+  val name = "Access Curation Page"
 }
 case object AccessRecipeVerificationPage extends OperationType {
-  override def toString: String = "Access Verification Page"
+  val name = "Access Verification Page"
 }
 
 case class UserEvent(

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -33,7 +33,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
 
   def viewRecipe(id: String) = AuthAction { implicit request =>
     val recipe = db.getOriginalRecipe(id)
-    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeReadOnlyPage.toString))
+    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeReadOnlyPage.name))
     curatedRecipedEditor(recipe, editable = false)
   }
 
@@ -57,7 +57,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
       case Some(recipe) => {
         if (recipe.status == Ready || recipe.status == Pending) {
           db.setOriginalRecipeStatus(recipe.id, Pending)
-          db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeCurationPage.toString))
+          db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeCurationPage.name))
           curatedRecipedEditor(db.getOriginalRecipe(id), editable = true)
         } else {
           Redirect(routes.Application.viewRecipe(recipe.id)) // redirection to read only
@@ -71,7 +71,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     val recipe = db.getOriginalRecipe(id)
     // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
     // But we need to record the fact that the recipe is being verified.
-    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeVerificationPage.toString))
+    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, AccessRecipeVerificationPage.name))
     curatedRecipedEditor(recipe, editable = true)
   }
 


### PR DESCRIPTION
In this change (the first of two refactoring changes), we apply the method used in
this commit: https://github.com/guardian/recipeasy/commit/d5ce6dc1ceec19855b9d56993144ea1605d5af84
to make the code more robust and less amendable to accidental breaks.

Note that in the case of `sealed trait OperationType` we had already used the type itself
but relied on function `toString` instead of a value and this wasn't working with Quill.
This change therefore moves `OperationType`'s `toString` functions to names.