### PR TITLE
Refactoring: Types renaming

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Recipe.scala
@@ -19,13 +19,13 @@ case class Steps(steps: Seq[String])
 
 sealed trait RecipeStatus { val name: String }
 
-case object New extends RecipeStatus { val name = "New" }
-case object Ready extends RecipeStatus { val name = "Ready" }
-case object Pending extends RecipeStatus { val name = "Pending" }
-case object Curated extends RecipeStatus { val name = "Curated" }
-case object Verified extends RecipeStatus { val name = "Verified" }
-case object Finalised extends RecipeStatus { val name = "Finalised" }
-case object Impossible extends RecipeStatus { val name = "Impossible" }
+case object RecipeStatusNew extends RecipeStatus { val name = "New" }
+case object RecipeStatusReady extends RecipeStatus { val name = "Ready" }
+case object RecipeStatusPending extends RecipeStatus { val name = "Pending" }
+case object RecipeStatusCurated extends RecipeStatus { val name = "Curated" }
+case object RecipeStatusVerified extends RecipeStatus { val name = "Verified" }
+case object RecipeStatusFinalised extends RecipeStatus { val name = "Finalised" }
+case object RecipeStatusImpossible extends RecipeStatus { val name = "Impossible" }
 
 /*
 

--- a/common/src/main/scala/com/gu/recipeasy/models/RecipeReadiness.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/RecipeReadiness.scala
@@ -9,20 +9,20 @@ import scala.collection.JavaConverters._
 object RecipeReadiness {
 
   def selectNewRecipesWithNonEmptyIngredientLists(db: DB): List[Recipe] = {
-    db.getOriginalRecipes().filter(recipe => ((recipe.ingredientsLists.lists.size > 0) && (recipe.status == New)))
+    db.getOriginalRecipes().filter(recipe => ((recipe.ingredientsLists.lists.size > 0) && (recipe.status == RecipeStatusNew)))
   }
   def migrateNewRecipesWithNonEmptyIngredientLists(db: DB): Int = {
     val recipes: List[Recipe] = selectNewRecipesWithNonEmptyIngredientLists(db)
-    recipes.foreach(recipe => db.setOriginalRecipeStatus(recipe.id, Ready))
+    recipes.foreach(recipe => db.setOriginalRecipeStatus(recipe.id, RecipeStatusReady))
     recipes.size
   }
 
   def selectNigelSlaterRecipes(db: DB): List[Recipe] = {
-    db.getOriginalRecipes().filter(_.status != Impossible).filter(_.credit.exists(_.contains("Nigel Slater")))
+    db.getOriginalRecipes().filter(_.status != RecipeStatusImpossible).filter(_.credit.exists(_.contains("Nigel Slater")))
   }
   def migrateNigelSlaterRecipes(db: DB): Int = {
-    val recipes: List[Recipe] = selectNigelSlaterRecipes(db).filter(_.status != Impossible)
-    recipes.foreach(recipe => db.setOriginalRecipeStatus(recipe.id, Impossible))
+    val recipes: List[Recipe] = selectNigelSlaterRecipes(db).filter(_.status != RecipeStatusImpossible)
+    recipes.foreach(recipe => db.setOriginalRecipeStatus(recipe.id, RecipeStatusImpossible))
     recipes.size
   }
 
@@ -112,7 +112,7 @@ object RecipeReadiness {
 
   def reparseNewRecipesWithEmptyIngredientLists(db: DB): Int = {
     val recipes: List[Recipe] = db.getOriginalRecipes()
-      .filter(_.status == New)
+      .filter(_.status == RecipeStatusNew)
       .filter(_.ingredientsLists.lists.size == 0) // selecting the ones with empty ingredient lists
       .filter(recipe => !isEmptyIngredientsLists(db, recipe)) // selecting the one which have not been acted on yet
       .filter(recipe => extractIngredientsLists(recipe).size > 0)

--- a/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
@@ -33,15 +33,15 @@ object Leaderboard {
     }
 
     def eventsToCurationNumber(events: List[UserEventDB]): Int = {
-      events.filter(event => event.operation_type == Curation.name).size
+      events.filter(event => event.operation_type == UserEventCuration.name).size
     }
 
     def eventsToVerificationNumber(events: List[UserEventDB]): Int = {
-      events.filter(event => event.operation_type == Verification.name).size
+      events.filter(event => event.operation_type == UserEventVerification.name).size
     }
 
     def eventsToConfirmationNumber(events: List[UserEventDB]): Int = {
-      events.filter(event => event.operation_type == Confirmation.name).size
+      events.filter(event => event.operation_type == UserEventConfirmation.name).size
     }
 
     events.map(event => event.user_email).distinct.map { email =>

--- a/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
@@ -4,24 +4,24 @@ import automagic._
 import java.util.Calendar
 import java.time.OffsetDateTime
 
-sealed trait OperationType { val name: String }
+sealed trait UserEventOperationType { val name: String }
 
-case object Curation extends OperationType {
+case object UserEventCuration extends UserEventOperationType {
   val name = "Curation"
 }
-case object Verification extends OperationType {
+case object UserEventVerification extends UserEventOperationType {
   val name = "Verification"
 }
-case object Confirmation extends OperationType {
+case object UserEventConfirmation extends UserEventOperationType {
   val name = "Confirmation"
 }
-case object AccessRecipeReadOnlyPage extends OperationType {
+case object UserEventAccessRecipeReadOnlyPage extends UserEventOperationType {
   val name = "Recipe Read Only Page"
 }
-case object AccessRecipeCurationPage extends OperationType {
+case object UserEventAccessRecipeCurationPage extends UserEventOperationType {
   val name = "Access Curation Page"
 }
-case object AccessRecipeVerificationPage extends OperationType {
+case object UserEventAccessRecipeVerificationPage extends UserEventOperationType {
   val name = "Access Verification Page"
 }
 

--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -149,7 +149,7 @@ object ETL extends App {
           articleId = content.id,
           credit = content.fields.flatMap(_.byline),
           publicationDate,
-          status = New,
+          status = RecipeStatusNew,
           steps = Steps(r.steps)
         )
     }

--- a/ui/app/com/gu/recipeasy/views/admin/statusdistribution.scala.html
+++ b/ui/app/com/gu/recipeasy/views/admin/statusdistribution.scala.html
@@ -15,31 +15,31 @@
         <tbody>
             <tr>
                 <td>New</td>
-                <td>@distribution(New)</td>
+                <td>@distribution(RecipeStatusNew)</td>
             </tr>
             <tr>
                 <td>Ready</td>
-                <td>@distribution(Ready)</td>
+                <td>@distribution(RecipeStatusReady)</td>
             </tr>
             <tr>
                 <td>Pending</td>
-                <td>@distribution(Pending)</td>
+                <td>@distribution(RecipeStatusPending)</td>
             </tr>
             <tr>
                 <td>Curated</td>
-                <td>@distribution(Curated)</td>
+                <td>@distribution(RecipeStatusCurated)</td>
             </tr>
             <tr>
                 <td>Verified</td>
-                <td>@distribution(Verified)</td>
+                <td>@distribution(RecipeStatusVerified)</td>
             </tr>
             <tr>
                 <td>Finalised</td>
-                <td>@distribution(Finalised)</td>
+                <td>@distribution(RecipeStatusFinalised)</td>
             </tr>
             <tr>
                 <td>Impossible</td>
-                <td>@distribution(Impossible)</td>
+                <td>@distribution(RecipeStatusImpossible)</td>
             </tr>
         </tbody>
     </table>

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -12,11 +12,11 @@
 @pageTopMessage(status: RecipeStatus) = @{
     if(isEditable){
         status match {
-            case New        => "Creation, pass 1 of 3."
-            case Pending    => "Creation, pass 1 of 3."
-            case Curated    => "Verification, pass 2 of 3."
-            case Verified   => "Final Check, pass 3 of 3."
-            case Finalised  => "Final Check, pass 3 of 3."
+            case RecipeStatusNew        => "Creation, pass 1 of 3."
+            case RecipeStatusPending    => "Creation, pass 1 of 3."
+            case RecipeStatusCurated    => "Verification, pass 2 of 3."
+            case RecipeStatusVerified   => "Final Check, pass 3 of 3."
+            case RecipeStatusFinalised  => "Final Check, pass 3 of 3."
             case _ => ""
         }
     }else{
@@ -26,8 +26,8 @@
 @showSkipThisRecipeButton(status: RecipeStatus) = @{
     if(isEditable){
         status match {
-            case New     => true
-            case Pending => true
+            case RecipeStatusNew     => true
+            case RecipeStatusPending => true
             case _       => false
         }
     }else{
@@ -37,11 +37,11 @@
 }
 @topBannerStatusClass(status: RecipeStatus) = @{
     status match {
-        case New        => "top-banner-phase-creation"
-        case Pending    => "top-banner-phase-creation"
-        case Curated    => "top-banner-phase-verification"
-        case Verified   => "top-banner-phase-final"
-        case Finalised  => "top-banner-phase-final"
+        case RecipeStatusNew        => "top-banner-phase-creation"
+        case RecipeStatusPending    => "top-banner-phase-creation"
+        case RecipeStatusCurated    => "top-banner-phase-verification"
+        case RecipeStatusVerified   => "top-banner-phase-final"
+        case RecipeStatusFinalised  => "top-banner-phase-final"
         case _ => ""
     }
 }
@@ -56,8 +56,8 @@
             @if(!isEditable){
                 <button type="button" class="btn btn-sm btn-warning">This page is read only</button>
             }
-            @if(isEditable && (status==Curated)){You are verifying the quality of the original curation}
-            @if(isEditable && (status==Verified)){Final opportunity for corrections. Could you cook this?}
+            @if(isEditable && (status==RecipeStatusCurated)){You are verifying the quality of the original curation}
+            @if(isEditable && (status==RecipeStatusVerified)){Final opportunity for corrections. Could you cook this?}
         </span>
         <form class="form-inline float-xs-right">
             <a href="@routes.Application.tutorial" target="_blank" class="btn btn-sm align-middle btn-info" role="button">Tutorial</a>

--- a/ui/test/com/gu/recipeasy/ApplicationSpec.scala
+++ b/ui/test/com/gu/recipeasy/ApplicationSpec.scala
@@ -30,7 +30,7 @@ class recipeConversion extends FlatSpec with Matchers {
       articleId = "breakfast",
       credit = None,
       publicationDate = time,
-      status = New,
+      status = RecipeStatusNew,
       steps = Steps(List.empty)
     )
 


### PR DESCRIPTION
Because of linguistic similarities between the names of RecipeStatus and OperationType, the code is
sometimes difficult to follow. For instance `case object Curation` and `case object Curated` sometimes
cause confusion.

This change, ( the second part of https://github.com/guardian/recipeasy/commit/9d6a10bb11ba25da851285e0b6c374d1094bb98f )
solves that problem.

As an example, the code of the following function makes more sense, and hilights better that both user events and recipes status are involved in the resuling query
```
  def getUserSpecificRecipeForVerificationStep(userEmail: String): Option[Recipe] = {
    val recipeIdsAlreadyTouchedByThisUser = quote {
      query[UserEventDB].schema(_.entity("user_events"))
        .filter(event => event.user_email == lift(userEmail))
        .filter(event => ((event.operation_type == lift(UserEventCuration.name)) || (event.operation_type == lift(UserEventVerification.name)) || (event.operation_type == lift(UserEventConfirmation.name))))
        .map(event => event.recipe_id)
    }
    val q2 = quote {
      query[Recipe]
        .filter(r => ((r.status == lift(RecipeStatusCurated.name)) || (r.status == lift(RecipeStatusVerified.name))))
        .filter(r => !recipeIdsAlreadyTouchedByThisUser.contains(r.id))
        .take(1)
    }
    contextWrapper.dbContext.run(q2).headOption
  }
```