### PR TITLE
Correction of commit ae3e48e3fd6ae7dce1c317db9b4e07c1124142c5

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -341,6 +341,16 @@ class DB(contextWrapper: ContextWrapper) {
     userEventsDates().sorted.map(date => DayActivityDistribution(date, eventsForDateAndOperationType(date, UserEventCuration).size, eventsForDateAndOperationType(date, UserEventVerification).size, eventsForDateAndOperationType(date, UserEventConfirmation).size))
   }
 
+  def getFirstCurationEventForRecipe(recipeId: String): Option[UserEventDB] = {
+    val q = quote {
+      query[UserEventDB].schema(_.entity("user_events"))
+        .filter(event => event.recipe_id == lift(recipeId))
+        .filter(event => event.operation_type == lift(UserEventCuration.name))
+        .sortBy(event => event.event_datetime)(Ord.asc)
+    }
+    contextWrapper.dbContext.run(q).headOption
+  }
+
   // ---------------------------------------------
   // Stats
 

--- a/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
@@ -4,6 +4,8 @@ import automagic._
 import java.util.Calendar
 import java.time.OffsetDateTime
 
+import com.gu.recipeasy.db.DB
+
 sealed trait UserEventOperationType { val name: String }
 
 case object UserEventCuration extends UserEventOperationType {
@@ -53,3 +55,13 @@ case class UserEventDB(
   operation_type: String
 )
 
+case class CurationUser(emailAddress: String, firstName: String, lastName: String)
+
+object CurationUser {
+  def getCurationUser(recipeId: String, db: DB): CurationUser = {
+    db.getFirstCurationEventForRecipe(recipeId) match {
+      case Some(userEventDB) => CurationUser(userEventDB.user_email, userEventDB.user_firstname, userEventDB.user_lastname)
+      case None => CurationUser("off-platform@guardian.co.uk", "off-platform", "")
+    }
+  }
+}

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -34,7 +34,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
   def viewRecipe(id: String) = AuthAction { implicit request =>
     val recipe = db.getOriginalRecipe(id)
     db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, UserEventAccessRecipeReadOnlyPage.name))
-    curatedRecipedEditor(recipe, editable = false, userEmail = request.user.email, userFirstName = request.user.firstName, userLastName = request.user.lastName)
+    curatedRecipedEditor(recipe, editable = false, curationUser = CurationUser.getCurationUser(id, db))
   }
 
   def curateOrVerify() = AuthAction { implicit request =>
@@ -58,7 +58,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
         if (recipe.status == RecipeStatusReady || recipe.status == RecipeStatusPending) {
           db.setOriginalRecipeStatus(recipe.id, RecipeStatusPending)
           db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, UserEventAccessRecipeCurationPage.name))
-          curatedRecipedEditor(db.getOriginalRecipe(id), editable = true, userEmail = request.user.email, userFirstName = request.user.firstName, userLastName = request.user.lastName)
+          curatedRecipedEditor(db.getOriginalRecipe(id), editable = true, curationUser = CurationUser.getCurationUser(id, db))
         } else {
           Redirect(routes.Application.viewRecipe(recipe.id)) // redirection to read only
         }
@@ -72,14 +72,14 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
     // But we need to record the fact that the recipe is being verified.
     db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, id, UserEventAccessRecipeVerificationPage.name))
-    curatedRecipedEditor(recipe, editable = true, userEmail = request.user.email, userFirstName = request.user.firstName, userLastName = request.user.lastName)
+    curatedRecipedEditor(recipe, editable = true, curationUser = CurationUser.getCurationUser(id, db))
   }
 
   def finalCheckRecipe(id: String) = AuthAction { implicit request =>
     val recipe = db.getOriginalRecipe(id)
     // We reuse the code for `curateRecipe` because curation and verification use the same logic and the same editor
     // But we need to record the fact that the recipe is being verified.
-    curatedRecipedEditor(recipe, editable = true, userEmail = request.user.email, userFirstName = request.user.firstName, userLastName = request.user.lastName)
+    curatedRecipedEditor(recipe, editable = true, curationUser = CurationUser.getCurationUser(id, db))
   }
 
   def curateOneRecipeInNewStatus = AuthAction { implicit request =>
@@ -205,7 +205,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
   private[this] def curatedRecipedEditor(
     recipe: Option[Recipe],
     editable: Boolean,
-    userEmail: String, userFirstName: String, userLastName: String
+    curationUser: CurationUser
   )(implicit request: RequestHeader) = {
     recipe match {
       case Some(r) => {
@@ -228,9 +228,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
           editable,
           images,
           r.status,
-          userEmail,
-          userFirstName,
-          userLastName
+          curationUser
         ))
 
       }

--- a/ui/app/com/gu/recipeasy/views/recipe.scala.html
+++ b/ui/app/com/gu/recipeasy/views/recipe.scala.html
@@ -6,9 +6,7 @@
         isEditable: Boolean,
         images: List[ImageDB],
         status: RecipeStatus,
-        userEmailAddress: String,
-        userFirstname: String,
-        userLastname: String
+        curationUser: CurationUser
 )(implicit messages: play.api.i18n.Messages, request: RequestHeader)
 @import helper.CSRF
 @implicitFC = @{ b4.vertical.fieldConstructor }
@@ -60,8 +58,8 @@
             @if(!isEditable){
                 <button type="button" class="btn btn-sm btn-warning">This page is read only</button>
             }
-            @if(isEditable && (status==RecipeStatusCurated)){You are verifying the quality of the original curation by <a href="mailto:@{userEmailAddress}" target="_top">@{userFirstname} @{userLastname}</a>.}
-            @if(isEditable && (status==RecipeStatusVerified)){Final opportunity for corrections ( Original Curation by <a href="mailto:@{userEmailAddress}" target="_top">@{userFirstname} @{userLastname}</a>). Could you cook this?}
+            @if(isEditable && (status==RecipeStatusCurated)){You are verifying the quality of the original curation by <a href="mailto:@{curationUser.emailAddress}" target="_top">@{curationUser.firstName} @{curationUser.lastName}</a>.}
+            @if(isEditable && (status==RecipeStatusVerified)){Final opportunity for corrections ( Original Curation by <a href="mailto:@{curationUser.emailAddress}" target="_top">@{curationUser.firstName} @{curationUser.lastName}</a>). Could you cook this?}
         </span>
         <form class="form-inline float-xs-right">
             <a href="@routes.Application.tutorial" target="_blank" class="btn btn-sm align-middle btn-info" role="button">Tutorial</a>


### PR DESCRIPTION
The previous commit is incorrect because the displayed name is not meant to be the current user but the
user who has performed the curation.
(This mistake wasn't apparent at the moment the PR was done because on my computer both users are teh same).

This commit introduces the database function `getFirstCurationEventForRecipe(recipeId: String): Option[UserEventDB]`
which extracts an optional UserEventDB.

It is used by `getCurationUser(recipeId: String, db: DB): CurationUser`
which given a recipeId and a database object returns a CurationUser. Note that a
CurationUser is always returned, even if the previous function returned null, this to keep the code of the
Application controller and the code of the view more simple.