### PR TITLE
Recipeasy: Get image assets for a curated recipe.

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -1,13 +1,8 @@
 package com.gu.recipeasy.models
 
 import automagic._
-import io.circe._
-import cats.data.Xor
-import CuratedRecipeDB._
-import ImageDB._
-
+import com.gu.contentatom.thrift.{ Atom, AtomData, AtomType, ChangeRecord, ContentChangeDetails, User, Image => AtomImage }
 import com.gu.contentatom.thrift.atom.{ recipe => atom }
-import com.gu.contentatom.thrift._
 
 case class CuratedRecipe(
   id: Long,
@@ -121,7 +116,7 @@ object CuratedRecipe {
     }
   }
 
-  def toAtom(r: Recipe, cr: CuratedRecipe): Atom = {
+  def toAtom(r: Recipe, cr: CuratedRecipe, curatedRecipeImages: Seq[AtomImage]): Atom = {
 
     val contentChangeDetails = ContentChangeDetails(
       created = Some(
@@ -185,7 +180,7 @@ object CuratedRecipe {
         )),
       steps = cr.steps.steps,
       credits = cr.credit.toList,
-      images = Nil
+      images = curatedRecipeImages
     )
 
     Atom(

--- a/ui/app/com/gu/recipeasy/controllers/Publisher.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Publisher.scala
@@ -2,24 +2,22 @@ package controllers
 
 import com.gu.recipeasy.auth.AuthActions
 import com.gu.recipeasy.db.DB
-import com.gu.recipeasy.models.{ Recipe, CuratedRecipe }
-import com.gu.contentatom.thrift.{ ContentAtomEvent, EventType }
+import com.gu.recipeasy.models.{ CuratedRecipe, Images, Recipe }
+import com.gu.contentatom.thrift._
 import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{ AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType }
-
 import java.time.OffsetDateTime
 
+import com.gu.recipeasy.services.ContentApi
 import services.{ AtomPublisher, PublisherConfig, Teleporter }
-
 import play.api.Configuration
 import play.api.libs.ws.WSClient
-import play.api.mvc.{ Action, Controller }
+import play.api.mvc.Controller
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 import scala.concurrent.Future
-
 import com.typesafe.scalalogging.StrictLogging
 
-class Publisher(override val wsClient: WSClient, override val conf: Configuration, config: PublisherConfig, db: DB, teleporter: Teleporter) extends Controller with AuthActions with StrictLogging {
+class Publisher(override val wsClient: WSClient, override val conf: Configuration, config: PublisherConfig, db: DB, teleporter: Teleporter, contentApi: ContentApi) extends Controller with AuthActions with StrictLogging {
 
   def publish(id: String) = AuthAction.async { implicit request =>
     db.getOriginalRecipe(id) match {
@@ -30,8 +28,14 @@ class Publisher(override val wsClient: WSClient, override val conf: Configuratio
 
             import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-            teleporter.getInternalComposerCode(recipe.articleId).map { internalComposerCode =>
-              val result = send(internalComposerCode, recipe, curatedRecipe)(config)
+            val futureImages = contentApi.findImagesForRecipe(recipe.articleId, curatedRecipe)
+            val futureInternalComposerCode = teleporter.getInternalComposerCode(recipe.articleId)
+
+            for {
+              curatedRecipeImages <- futureImages
+              internalComposerCode <- futureInternalComposerCode
+            } yield {
+              val result = send(internalComposerCode, recipe, curatedRecipe, curatedRecipeImages)(config)
               result match {
                 case Success(_) => Ok(s"Publishing content atom")
                 case Failure(error) =>
@@ -46,10 +50,10 @@ class Publisher(override val wsClient: WSClient, override val conf: Configuratio
     }
   }
 
-  private def send(internalComposerCode: String, recipe: Recipe, curatedRecipe: CuratedRecipe)(config: PublisherConfig) = {
+  private def send(internalComposerCode: String, recipe: Recipe, curatedRecipe: CuratedRecipe, curatedRecipeImages: Seq[Image])(config: PublisherConfig) = {
 
     val atomEvents: (AuxiliaryAtomEvent, ContentAtomEvent) = {
-      val contentAtom = CuratedRecipe.toAtom(recipe, curatedRecipe)
+      val contentAtom = CuratedRecipe.toAtom(recipe, curatedRecipe, curatedRecipeImages)
       val auxiliaryAtomEvent = AuxiliaryAtomEvent(internalComposerCode, eventType = AuxiliaryAtomEventType.Add, Seq(AuxiliaryAtom(contentAtom.id, "recipe")))
       val contentAtomEvent = ContentAtomEvent(contentAtom, EventType.Update, eventCreationTime = OffsetDateTime.now.toInstant.toEpochMilli)
       (auxiliaryAtomEvent, contentAtomEvent)

--- a/ui/app/com/gu/recipeasy/services/ContentApi.scala
+++ b/ui/app/com/gu/recipeasy/services/ContentApi.scala
@@ -1,0 +1,45 @@
+package com.gu.recipeasy.services
+
+import com.gu.contentapi.client.GuardianContentClient
+import com.gu.contentapi.client.model.v1.{ Asset, Element }
+import com.gu.contentatom.thrift.{ Image, ImageAsset, ImageAssetDimensions }
+import com.gu.recipeasy.models.CuratedRecipe
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class ContentApi(contentApiClient: GuardianContentClient) {
+
+  def findImagesForRecipe(articleId: String, curatedRecipe: CuratedRecipe)(implicit ec: ExecutionContext): Future[Seq[Image]] = {
+
+    val itemQuery = contentApiClient.item(articleId).showElements("image")
+
+    def toImageAsset(asset: Asset): ImageAsset = {
+      ImageAsset(
+        mimeType = asset.mimeType,
+        file = asset.file.getOrElse(""),
+        dimensions = asset.typeData.flatMap { td => for (height <- td.height; width <- td.width) yield ImageAssetDimensions(height, width) },
+        size = None
+      )
+    }
+
+    def toImages(imageElements: Seq[Element]): Seq[Image] = {
+      imageElements.map { imageElement =>
+        val imageAssets = imageElement.assets map toImageAsset
+        Image(
+          assets = imageAssets,
+          master = imageAssets.headOption,
+          mediaId = imageElement.id
+        )
+      }
+    }
+
+    contentApiClient.getResponse(itemQuery).map { recipeArticle =>
+
+      val images = (for (content <- recipeArticle.content; elements <- content.elements) yield toImages(elements)).getOrElse(Nil)
+      val imageIdsSelectedForRecipe = curatedRecipe.images.images.map(_.mediaId)
+
+      images.filter(image => imageIdsSelectedForRecipe.contains(image.mediaId))
+    }
+  }
+
+}

--- a/ui/app/com/gu/recipeasy/services/PublisherConfig.scala
+++ b/ui/app/com/gu/recipeasy/services/PublisherConfig.scala
@@ -1,18 +1,12 @@
 package services
 
-import java.io.File
-
 import com.amazonaws.auth.{ AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider }
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider.Builder
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.regions.{ Region, Regions }
+import com.amazonaws.regions.Region
 import com.amazonaws.services.kinesis.AmazonKinesisClient
-import com.gu.contentapi.client.GuardianContentClient
 import play.api.Configuration
 
-import scala.util.Try
-
-case class ContentAtomConfig(streamName: String, stsRoleArn: String, kinesisClient: AmazonKinesisClient)
+case class ContentAtomConfig(streamName: String, stsRoleArn: String, kinesisClient: AmazonKinesisClient, capiKey: String)
 case class AuxiliaryAtomConfig(streamName: String, stsRoleArn: String, kinesisClient: AmazonKinesisClient)
 case class PublisherConfig(contentAtomConfig: ContentAtomConfig, auxiliaryAtomConfig: AuxiliaryAtomConfig)
 
@@ -23,6 +17,8 @@ object PublisherConfig {
     val contentAtomStreamName = s"content-atom-events-live-${stage.toUpperCase}"
 
     val contentAtomStsRoleArn = config.getString("aws.atom.content.stsRoleArn").getOrElse("")
+
+    val contentApiKey = config.getString("capi.key").getOrElse("")
 
     val contentAtomConfig = ContentAtomConfig(
       contentAtomStreamName,
@@ -36,7 +32,8 @@ object PublisherConfig {
       val kinesisClient = new AmazonKinesisClient(kinesisCredentialsProvider)
       kinesisClient.setRegion(region)
       kinesisClient
-    }
+    },
+      capiKey = contentApiKey
     )
 
     val auxiliaryAtomStreamName = s"auxiliary-atom-feed-${stage.toUpperCase}"

--- a/ui/app/com/gu/recipeasy/services/Teleporter.scala
+++ b/ui/app/com/gu/recipeasy/services/Teleporter.scala
@@ -1,11 +1,6 @@
 package services
 
-import java.util.concurrent.Executors
 import play.api.libs.ws.WSClient
-import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Await }
-import scala.util.Try
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 


### PR DESCRIPTION
In order to correctly display recipes with rich cards it's required that it has an image. This change adds all of the image assets to a curatedRecipe (given the images that were selected) for publication to CAPI as a content atom.