### PR TITLE
Fix: incorrect call to .tail on a possibly empty list

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
@@ -71,16 +71,24 @@ object UsersSpeedsMeasurements {
       val userEvents = userEventsAll.filter(event => event.user_email == email)
 
       val curationEvents = userEvents.filter(event => (event.operation_type == UserEventAccessRecipeCurationPage.name || event.operation_type == UserEventCuration.name))
-      val curationTimings: List[Double] = curationEvents.zip(curationEvents.tail)
-        .filter(events => pairOfEventsIsNormalised(events, UserEventAccessRecipeCurationPage.name, UserEventCuration.name))
-        .map(events => secondsBetweenEvents(events._1, events._2))
-        .filter(timing => timing <= 1200)
+      val curationTimings: List[Double] = if (curationEvents.nonEmpty) {
+        curationEvents.zip(curationEvents.tail)
+          .filter(events => pairOfEventsIsNormalised(events, UserEventAccessRecipeCurationPage.name, UserEventCuration.name))
+          .map(events => secondsBetweenEvents(events._1, events._2))
+          .filter(timing => timing <= 1200)
+      } else {
+        Nil
+      }
 
       val verificationEvents = userEvents.filter(event => (event.operation_type == UserEventAccessRecipeVerificationPage.name || event.operation_type == UserEventVerification.name))
-      val verificationTimings: List[Double] = verificationEvents.zip(verificationEvents.tail)
-        .filter(events => pairOfEventsIsNormalised(events, UserEventAccessRecipeVerificationPage.name, UserEventVerification.name))
-        .map(events => secondsBetweenEvents(events._1, events._2))
-        .filter(timing => timing <= 1200)
+      val verificationTimings: List[Double] = if (verificationEvents.nonEmpty) {
+        verificationEvents.zip(verificationEvents.tail)
+          .filter(events => pairOfEventsIsNormalised(events, UserEventAccessRecipeVerificationPage.name, UserEventVerification.name))
+          .map(events => secondsBetweenEvents(events._1, events._2))
+          .filter(timing => timing <= 1200)
+      } else {
+        Nil
+      }
 
       (
         email,


### PR DESCRIPTION
This change corrects a runtime bug appearing when a user doesn't have at least one curation or verification step.