### PR TITLE
Change in leaderboard comparison function

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/Statistics.scala
@@ -49,7 +49,7 @@ object Leaderboard {
     events.map(event => event.user_email).distinct.map { email =>
       val userEvents = eventsForEmailAddress(events, email)
       LeaderboardEntry(email, eventsToCurationNumber(userEvents), eventsToVerificationNumber(userEvents), eventsToConfirmationNumber(userEvents))
-    }.sortWith((le1, le2) => le1.total <= le2.total).reverse
+    }.sortWith((le1, le2) => le1.total < le2.total).reverse
 
   }
 }


### PR DESCRIPTION
This small change prevents two objects that are not actually the same object
to be rendered equal by the comparison function.

The order has to be an antisymmetric relation
https://en.wikipedia.org/wiki/Antisymmetric_relation