### PR TITLE
Publish curated recipes

### DIFF
--- a/ui/app/com/gu/recipeasy/AppComponents.scala
+++ b/ui/app/com/gu/recipeasy/AppComponents.scala
@@ -61,14 +61,13 @@ class AppComponents(context: Context)
   val googleGroupsAuthorizer = if (context.environment.mode == play.api.Mode.Prod) { new GoogleGroupsAuthorisation(configuration) } else { new GoogleGroupsAuthorisationDummy() }
 
   val healthcheckController = new Healthcheck
-  val applicationController = new Application(wsClient, configuration, db, messagesApi)
 
   val publisherController = {
     val publisherConfig = PublisherConfig(configuration, region, identity.stage)
     val contentApiClient = new ContentApi(contentApiClient = new GuardianContentClient(publisherConfig.contentAtomConfig.capiKey))
     new Publisher(wsClient, configuration, publisherConfig, db, teleporter, contentApiClient)
   }
-
+  val applicationController = new Application(wsClient, configuration, db, messagesApi, publisherController)
   val loginController = new Login(wsClient, configuration)
   val adminController = new Admin(wsClient, configuration, db, messagesApi, googleGroupsAuthorizer)
 

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -5,16 +5,17 @@ import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.data._
 import play.api.data.format.Formats._
-import play.api.i18n.{ I18nSupport, MessagesApi }
+import play.api.i18n.{I18nSupport, MessagesApi}
 import com.typesafe.scalalogging.StrictLogging
 import com.gu.recipeasy.auth.AuthActions
 import com.gu.recipeasy.db._
 import com.gu.recipeasy.models._
+import com.gu.recipeasy.services.RecipePublisher
 import com.gu.recipeasy.views
 import models._
 import models.CuratedRecipeForm._
 
-class Application(override val wsClient: WSClient, override val conf: Configuration, db: DB, val messagesApi: MessagesApi, publisher: Publisher) extends Controller with AuthActions with I18nSupport with StrictLogging {
+class Application(override val wsClient: WSClient, override val conf: Configuration, db: DB, val messagesApi: MessagesApi) extends Controller with AuthActions with I18nSupport with StrictLogging {
 
   def index = AuthAction { implicit request =>
     val progressBarPercentage: Double = (db.progressBarRatio() * 10000).toInt.toDouble / 100
@@ -127,7 +128,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
       db.insertCuratedRecipe(curatedRecipeWithId)
       db.moveRecipeStatusFromPendingStateToNextStableState(recipeId)
       db.getOriginalRecipeStatus(recipeId).foreach(status => db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, recipeId, recipeStatusToUserEventOperationType(status))))
-      publisher.publish(curatedRecipeWithId.recipeId)
+      RecipePublisher.publishRecipe(curatedRecipeWithId.recipeId)
       Redirect(routes.Application.curateOrVerify)
     })
   }

--- a/ui/app/com/gu/recipeasy/controllers/Publisher.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Publisher.scala
@@ -1,41 +1,44 @@
 package controllers
 
-import com.gu.recipeasy.auth.AuthActions
-import com.gu.recipeasy.db.DB
-import com.gu.recipeasy.models.{ CuratedRecipe, Images, Recipe }
-import com.gu.contentatom.thrift._
-import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{ AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType }
 import java.time.OffsetDateTime
 
+import com.amazonaws.services.kinesis.model.PutRecordResult
+import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType}
+import com.gu.contentatom.thrift._
+import com.gu.recipeasy.auth.AuthActions
+import com.gu.recipeasy.db.DB
+import com.gu.recipeasy.models.{CuratedRecipe, Recipe}
 import com.gu.recipeasy.services.ContentApi
-import services.{ AtomPublisher, PublisherConfig, Teleporter }
+import com.typesafe.scalalogging.StrictLogging
 import play.api.Configuration
 import play.api.libs.ws.WSClient
-import play.api.mvc.Controller
+import play.api.mvc.{Action, Controller}
+import services.{AtomPublisher, PublisherConfig, Teleporter}
+import services.RecipePublisher
 
-import scala.util.{ Failure, Success }
 import scala.concurrent.Future
-import com.typesafe.scalalogging.StrictLogging
+import scala.util.{Failure, Success, Try}
 
 class Publisher(override val wsClient: WSClient, override val conf: Configuration, config: PublisherConfig, db: DB, teleporter: Teleporter, contentApi: ContentApi) extends Controller with AuthActions with StrictLogging {
 
-  def publish(id: String) = AuthAction.async { implicit request =>
+  /*
+val result = RecipePublisher.publishRecipe(recipe: Recipe, curatedRecipe: CuratedRecipe, config: PublisherConfig, teleporter: Teleporter, contentApi: ContentApi)
+result match {
+  case Success(_) => Ok(s"Publishing content atom")
+  case Failure(error) =>
+    logger.warn(s"Fail to publish content atom ${error.getMessage}", error)
+    Ok(s"Failed to publish content atom: ${error.getMessage}")
+}
+
+*/
+
+  def publish(id: String) = Action.async { implicit request =>
     db.getOriginalRecipe(id) match {
-
-      case Some(recipe) =>
+      case Some(recipe) => {
         db.getCuratedRecipeByRecipeId(recipe.id).map(CuratedRecipe.fromCuratedRecipeDB) match {
-          case Some(curatedRecipe) =>
-
-            import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
-            val futureImages = contentApi.findImagesForRecipe(recipe.articleId, curatedRecipe)
-            val futureInternalComposerCode = teleporter.getInternalComposerCode(recipe.articleId)
-
-            for {
-              curatedRecipeImages <- futureImages
-              internalComposerCode <- futureInternalComposerCode
-            } yield {
-              val result = send(internalComposerCode, recipe, curatedRecipe, curatedRecipeImages)(config)
+          case Some(curatedRecipe) => {
+            val fresult:Future[Try[List[PutRecordResult]]] = RecipePublisher.publishRecipe(recipe: Recipe, curatedRecipe: CuratedRecipe, config: PublisherConfig, teleporter: Teleporter, contentApi: ContentApi)
+            fresult.map{ result =>
               result match {
                 case Success(_) => Ok(s"Publishing content atom")
                 case Failure(error) =>
@@ -43,9 +46,11 @@ class Publisher(override val wsClient: WSClient, override val conf: Configuratio
                   Ok(s"Failed to publish content atom: ${error.getMessage}")
               }
             }
-
+            Future.successful(Ok(s"Publishing content atom"))
+          }
           case None => Future.successful(NotFound)
         }
+      }
       case None => Future.successful(NotFound)
     }
   }

--- a/ui/app/com/gu/recipeasy/services/RecipePublisher.scala
+++ b/ui/app/com/gu/recipeasy/services/RecipePublisher.scala
@@ -1,0 +1,37 @@
+package services
+
+import java.time.OffsetDateTime
+
+import com.amazonaws.services.kinesis.model.PutRecordResult
+import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType}
+import com.gu.contentatom.thrift._
+import com.gu.recipeasy.models.{CuratedRecipe, Recipe}
+import com.gu.recipeasy.services.ContentApi
+import scala.concurrent.Future
+
+import scala.util.Try
+
+object RecipePublisher {
+
+  def publishRecipe(recipe: Recipe, curatedRecipe: CuratedRecipe, config: PublisherConfig, teleporter: Teleporter, contentApi: ContentApi): Future[Try[List[PutRecordResult]]] = {
+    val futureImages = contentApi.findImagesForRecipe(recipe.articleId, curatedRecipe)
+    val futureInternalComposerCode = teleporter.getInternalComposerCode(recipe.articleId)
+    for {
+      curatedRecipeImages <- futureImages
+      internalComposerCode <- futureInternalComposerCode
+    } yield {
+      send(internalComposerCode, recipe, curatedRecipe, curatedRecipeImages)(config)
+    }
+  }
+
+  private def send(internalComposerCode: String, recipe: Recipe, curatedRecipe: CuratedRecipe, curatedRecipeImages: Seq[Image])(config: PublisherConfig): Try[List[PutRecordResult]] = {
+    val atomEvents: (AuxiliaryAtomEvent, ContentAtomEvent) = {
+      val contentAtom = CuratedRecipe.toAtom(recipe, curatedRecipe, curatedRecipeImages)
+      val auxiliaryAtomEvent = AuxiliaryAtomEvent(internalComposerCode, eventType = AuxiliaryAtomEventType.Add, Seq(AuxiliaryAtom(contentAtom.id, "recipe")))
+      val contentAtomEvent = ContentAtomEvent(contentAtom, EventType.Update, eventCreationTime = OffsetDateTime.now.toInstant.toEpochMilli)
+      (auxiliaryAtomEvent, contentAtomEvent)
+    }
+    AtomPublisher.send(atomEvents)(config)
+  }
+
+}


### PR DESCRIPTION
Change publishing so that curated recipes are immediately pushed to CAPI rather than waiting for 3 step verification process. To allow greater amount of data for testing.