### PR TITLE
Implements the atom publishing at each form submission

### DIFF
--- a/ui/app/com/gu/recipeasy/controllers/Publisher.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Publisher.scala
@@ -1,65 +1,38 @@
 package controllers
 
+import java.time.OffsetDateTime
+
+import com.amazonaws.services.kinesis.model.PutRecordResult
+import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{ AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType }
+import com.gu.contentatom.thrift._
 import com.gu.recipeasy.auth.AuthActions
 import com.gu.recipeasy.db.DB
 import com.gu.recipeasy.models.{ CuratedRecipe, Recipe }
-import com.gu.contentatom.thrift._
-import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{ AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType }
-import java.time.OffsetDateTime
-
 import com.gu.recipeasy.services.ContentApi
-import services.{ AtomPublisher, PublisherConfig, Teleporter }
+import com.typesafe.scalalogging.StrictLogging
 import play.api.Configuration
 import play.api.libs.ws.WSClient
-import play.api.mvc.Controller
+import play.api.mvc.{ Action, Controller }
+import services.{ AtomPublisher, PublisherConfig, Teleporter }
+import services.RecipePublisher
 
-import scala.util.{ Failure, Success }
 import scala.concurrent.Future
-import com.typesafe.scalalogging.StrictLogging
+import scala.util.{ Failure, Success, Try }
 
-class Publisher(override val wsClient: WSClient, override val conf: Configuration, config: PublisherConfig, db: DB, teleporter: Teleporter, contentApi: ContentApi) extends Controller with AuthActions with StrictLogging {
+import scala.concurrent.ExecutionContext.Implicits.global
 
-  def publish(id: String) = AuthAction.async { implicit request =>
-    db.getOriginalRecipe(id) match {
+class Publisher(override val wsClient: WSClient, override val conf: Configuration, publisherConfig: PublisherConfig, db: DB, teleporter: Teleporter, contentApi: ContentApi) extends Controller with AuthActions with StrictLogging {
 
-      case Some(recipe) =>
-        db.getCuratedRecipeByRecipeId(recipe.id).map(CuratedRecipe.fromCuratedRecipeDB) match {
-          case Some(curatedRecipe) =>
-
-            import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
-            val futureImages = contentApi.findImagesForRecipe(recipe.articleId, curatedRecipe)
-            val futureInternalComposerCode = teleporter.getInternalComposerCode(recipe.articleId)
-
-            for {
-              curatedRecipeImages <- futureImages
-              internalComposerCode <- futureInternalComposerCode
-            } yield {
-              val result = send(internalComposerCode, recipe, curatedRecipe, curatedRecipeImages)(config)
-              result match {
-                case Success(_) => Ok(s"Publishing content atom")
-                case Failure(error) =>
-                  logger.warn(s"Fail to publish content atom ${error.getMessage}", error)
-                  Ok(s"Failed to publish content atom: ${error.getMessage}")
-              }
-            }
-
-          case None => Future.successful(NotFound)
-        }
-      case None => Future.successful(NotFound)
+  def publish(recipeId: String) = Action.async { implicit request =>
+    val fresult: Future[Try[List[PutRecordResult]]] = RecipePublisher.publishRecipe(recipeId, db, publisherConfig, teleporter, contentApi)
+    fresult.map { result =>
+      result match {
+        case Success(_) => Ok(s"Publishing content atom")
+        case Failure(error) =>
+          logger.warn(s"Fail to publish content atom ${error.getMessage}", error)
+          Ok(s"Failed to publish content atom: ${error.getMessage}")
+      }
     }
-  }
-
-  private def send(internalComposerCode: String, recipe: Recipe, curatedRecipe: CuratedRecipe, curatedRecipeImages: Seq[Image])(config: PublisherConfig) = {
-
-    val atomEvents: (AuxiliaryAtomEvent, ContentAtomEvent) = {
-      val contentAtom = CuratedRecipe.toAtom(recipe, curatedRecipe, curatedRecipeImages)
-      val auxiliaryAtomEvent = AuxiliaryAtomEvent(internalComposerCode, eventType = AuxiliaryAtomEventType.Add, Seq(AuxiliaryAtom(contentAtom.id, "recipe")))
-      val contentAtomEvent = ContentAtomEvent(contentAtom, EventType.Update, eventCreationTime = OffsetDateTime.now.toInstant.toEpochMilli)
-      (auxiliaryAtomEvent, contentAtomEvent)
-    }
-
-    AtomPublisher.send(atomEvents)(config)
   }
 
 }

--- a/ui/app/com/gu/recipeasy/services/RecipePublisher.scala
+++ b/ui/app/com/gu/recipeasy/services/RecipePublisher.scala
@@ -1,0 +1,53 @@
+package services
+
+import java.time.OffsetDateTime
+
+import com.amazonaws.services.kinesis.model.PutRecordResult
+import com.gu.auxiliaryatom.model.auxiliaryatomevent.v1.{ AuxiliaryAtom, AuxiliaryAtomEvent, EventType => AuxiliaryAtomEventType }
+import com.gu.contentatom.thrift._
+import com.gu.recipeasy.db.DB
+import com.gu.recipeasy.models.{ CuratedRecipe, Recipe }
+import com.gu.recipeasy.services.ContentApi
+
+import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object RecipePublisher {
+
+  def publishRecipe(recipeId: String, db: DB, config: PublisherConfig, teleporter: Teleporter, contentApi: ContentApi): Future[Try[List[PutRecordResult]]] = {
+    db.getOriginalRecipe(recipeId) match {
+      case Some(recipe) => {
+        db.getCuratedRecipeByRecipeId(recipe.id).map(CuratedRecipe.fromCuratedRecipeDB) match {
+          case Some(curatedRecipe) => {
+            publishRecipeGivenRecipeAndCuratedRecipe(recipe: Recipe, curatedRecipe: CuratedRecipe, config: PublisherConfig, teleporter: Teleporter, contentApi: ContentApi)
+          }
+          case None => Future.successful(Try(throw new RuntimeException))
+        }
+      }
+      case None => Future.successful(Try(throw new RuntimeException))
+    }
+  }
+
+  private def publishRecipeGivenRecipeAndCuratedRecipe(recipe: Recipe, curatedRecipe: CuratedRecipe, config: PublisherConfig, teleporter: Teleporter, contentApi: ContentApi): Future[Try[List[PutRecordResult]]] = {
+    val futureImages = contentApi.findImagesForRecipe(recipe.articleId, curatedRecipe)
+    val futureInternalComposerCode = teleporter.getInternalComposerCode(recipe.articleId)
+    for {
+      curatedRecipeImages <- futureImages
+      internalComposerCode <- futureInternalComposerCode
+    } yield {
+      send(internalComposerCode, recipe, curatedRecipe, curatedRecipeImages)(config)
+    }
+  }
+
+  private def send(internalComposerCode: String, recipe: Recipe, curatedRecipe: CuratedRecipe, curatedRecipeImages: Seq[Image])(config: PublisherConfig): Try[List[PutRecordResult]] = {
+    val atomEvents: (AuxiliaryAtomEvent, ContentAtomEvent) = {
+      val contentAtom = CuratedRecipe.toAtom(recipe, curatedRecipe, curatedRecipeImages)
+      val auxiliaryAtomEvent = AuxiliaryAtomEvent(internalComposerCode, eventType = AuxiliaryAtomEventType.Add, Seq(AuxiliaryAtom(contentAtom.id, "recipe")))
+      val contentAtomEvent = ContentAtomEvent(contentAtom, EventType.Update, eventCreationTime = OffsetDateTime.now.toInstant.toEpochMilli)
+      (auxiliaryAtomEvent, contentAtomEvent)
+    }
+    AtomPublisher.send(atomEvents)(config)
+  }
+
+}


### PR DESCRIPTION
Change publishing so that curated recipes are immediately pushed to CAPI rather than waiting for 3 step verification process. To allow greater amount of data for testing.