### PR TITLE
Introduce a new user event UserEventAccessFrontPage

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/UserEvent.scala
@@ -26,6 +26,9 @@ case object UserEventAccessRecipeCurationPage extends UserEventOperationType {
 case object UserEventAccessRecipeVerificationPage extends UserEventOperationType {
   val name = "Access Verification Page"
 }
+case object UserEventAccessFrontPage extends UserEventOperationType {
+  val name = "Access-Front-Page"
+}
 
 case class UserEvent(
   user_email: String,

--- a/ui/app/com/gu/recipeasy/controllers/Application.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Application.scala
@@ -22,6 +22,7 @@ class Application(override val wsClient: WSClient, override val conf: Configurat
     val progressBarPercentage: Double = (db.progressBarRatio() * 10000).toInt.toDouble / 100
     val generalStats = db.generalStats()
     val userStats = db.userStats(request.user.email)
+    db.insertUserEvent(UserEvent(request.user.email, request.user.firstName, request.user.lastName, "", UserEventAccessFrontPage.name))
     Ok(views.html.app("Recipeasy", request.user.firstName, progressBarPercentage, generalStats, userStats))
   }
 

--- a/ui/app/com/gu/recipeasy/views/admin/recentactivity.scala.html
+++ b/ui/app/com/gu/recipeasy/views/admin/recentactivity.scala.html
@@ -30,7 +30,11 @@
                         <a href="@{routes.Admin.recentUserActivity(eventDB.user_email)}" target="_blank">user activity</a> (read only)
                     </td>
                     <td>
-                        <a href="@{routes.Application.viewRecipe(eventDB.recipe_id)}" target="_blank">recipe</a> (read only)
+                        @if(eventDB.recipe_id.size>0){
+                            <a href="@{routes.Application.viewRecipe(eventDB.recipe_id)}" target="_blank">recipe</a> (read only)
+                        }else{
+                         &nbsp;
+                        }
                     </td>
                 </tr>
             }

--- a/ui/app/com/gu/recipeasy/views/admin/recentuseractivity.scala.html
+++ b/ui/app/com/gu/recipeasy/views/admin/recentuseractivity.scala.html
@@ -28,7 +28,11 @@
                     <td>@{eventDB.user_email}</td>
                     <td>@{eventDB.operation_type}</td>
                     <td>
-                        <a href="@{routes.Application.viewRecipe(eventDB.recipe_id)}" target="_blank">recipe</a> (read only)
+                        @if(eventDB.recipe_id.size>0){
+                            <a href="@{routes.Application.viewRecipe(eventDB.recipe_id)}" target="_blank">recipe</a> (read only)
+                        }else{
+                            &nbsp;
+                        }
                     </td>
                 </tr>
             }


### PR DESCRIPTION
This introduce a new user event for an event that wasn't recorded
yet: a user accessing the front page (which would have been useful to me
this morning).

The admin pages are updated accordingly (it is the first event without an associated
recipe id).

![screen shot 2017-01-18 at 12 14 48](https://cloud.githubusercontent.com/assets/6035518/22063727/4f49b082-dd78-11e6-9f9e-dfb34da4bec5.png)
