### PR TITLE
Revert "Make tag fields lowercase in atom"

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
+++ b/common/src/main/scala/com/gu/recipeasy/models/CuratedRecipe.scala
@@ -150,10 +150,10 @@ object CuratedRecipe {
     val recipeAtom = atom.RecipeAtom(
       title = cr.title,
       tags = atom.Tags(
-        cuisine = cr.tags.list.collect { case Tag(value, "cuisines") => value.toLowerCase },
-        category = cr.tags.list.collect { case Tag(value, "category") => value.toLowerCase },
-        celebration = cr.tags.list.collect { case Tag(value, "holidays") => value.toLowerCase },
-        dietary = cr.tags.list.collect { case Tag(value, "dietary") => value.toLowerCase }
+        cuisine = cr.tags.list.collect { case Tag(value, "cuisines") => value },
+        category = cr.tags.list.collect { case Tag(value, "category") => value },
+        celebration = cr.tags.list.collect { case Tag(value, "holidays") => value },
+        dietary = cr.tags.list.collect { case Tag(value, "dietary") => value }
       ),
       time = atom.Time(
         preparation = {


### PR DESCRIPTION
Found a better way in concierge - https://github.com/guardian/content-api/pull/1837