### PR TITLE
adds logic to add images for articles with recipes and without images

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -122,6 +122,14 @@ class DB(contextWrapper: ContextWrapper) {
     }
   }
 
+  def getArticlesWithRecipes(): List[String] = {
+    contextWrapper.dbContext.run(quote(query[Recipe]).map(r => r.articleId).distinct)
+  }
+
+  def getArticlesWithSavedImages(): List[String] = {
+    contextWrapper.dbContext.run(quote(query[ImageDB].schema(_.entity("image"))).map(i => i.articleId).distinct)
+  }
+
   def insertImages(images: List[ImageDB]): Unit = {
     val table = quote(query[ImageDB].schema(_.entity("image")))
     try {

--- a/etl/src/main/scala/etl/ETL.scala
+++ b/etl/src/main/scala/etl/ETL.scala
@@ -71,12 +71,11 @@ object ETL extends App {
 
       //add images for articles with recipes and no images
       def articlesWithoutImages: Set[String] = db.getArticlesWithRecipes.toSet diff db.getArticlesWithSavedImages.toSet
-
-      articlesWithoutImages.foreach(a => {
-        capiClient.getResponse(ItemQuery(a)).foreach { itemResponse =>
+      articlesWithoutImages.foreach{ articleId =>
+        capiClient.getResponse(ItemQuery(articleId)).foreach { itemResponse =>
           db.insertImages(ImageExtraction.getImages(itemResponse.content).toList)
         }
-      })
+      }
 
     } finally {
       capiClient.shutdown()

--- a/etl/src/main/scala/etl/ImageExtraction.scala
+++ b/etl/src/main/scala/etl/ImageExtraction.scala
@@ -5,8 +5,11 @@ import com.gu.recipeasy.models.{ ImageDB }
 
 object ImageExtraction {
 
-  def getImages(content: Content, articleId: String): Seq[ImageDB] = {
-    findImageElements(content).flatMap(i => extractImageData(i, articleId))
+  def getImages(maybeContent: Option[Content]): Seq[ImageDB] = {
+    maybeContent match {
+      case Some(content) => findImageElements(content).flatMap(i => extractImageData(i, content.id))
+      case _ => Nil
+    }
   }
 
   private def findImageElements(content: Content): Seq[Element] = {


### PR DESCRIPTION
When ETL is run, after new articles are indexed...

- gets list of articles with recipes saved [A]
- gets list of articles with images saved [B]
- works out articles with missing images by diffing [A] and [B]


