### PR TITLE
Correction in the recipe table.

### DIFF
--- a/common/src/main/resources/db/migration/V10__correction_in_recipe_table.sql
+++ b/common/src/main/resources/db/migration/V10__correction_in_recipe_table.sql
@@ -1,0 +1,3 @@
+
+UPDATE recipe SET status = 'New' WHERE status = 'RecipeStatusNew';
+


### PR DESCRIPTION
The ETL script was run today against the production database, to add to the image table
missing entries. This was done after that commit https://github.com/guardian/recipeasy/commit/3cf2f8d935643081f3954bb5539be9eeb26703c9
hit production.

The image update has worked well, but recipes in "New":String status in the database
(those corresponding to the type `RecipeStatusNew`:`RecipeStatus`) that the ETL script
decided to update, ended up with the incorrect database status "RecipeStatusNew":String

This change records the SQL query to make that correction a part of the code history.

Note that the bug that caused this problem has been corrected here: https://github.com/guardian/recipeasy/commit/976c00e8b24117f63576bc7a07d51bcd7eec2ebd

Note also that this bug was not detected before today because the ETL script has never been ran against PROD since last October.

(The databse migration to correct prod will then be ran manually, has already been tested on local).