### PR TITLE
Article ID to Recipe IDs lookup

### DIFF
--- a/common/src/main/scala/com/gu/recipeasy/db/DB.scala
+++ b/common/src/main/scala/com/gu/recipeasy/db/DB.scala
@@ -165,6 +165,12 @@ class DB(contextWrapper: ContextWrapper) {
     contextWrapper.dbContext.run(quote(query[Recipe]).filter(r => r.id == lift(recipeId))).headOption
   }
 
+  def getOriginalRecipesByArticleId(articleId: String): List[Recipe] = {
+    contextWrapper.dbContext.run(
+      quote(query[Recipe]).filter(r => r.articleId == lift(articleId))
+    )
+  }
+
   def getOriginalRecipeInNewStatus(): Option[Recipe] = {
     contextWrapper.dbContext.run(quote(query[Recipe]).filter(r => r.status == lift(RecipeStatusNew.name)).sortBy(r => r.publicationDate)(Ord.desc).take(1)).headOption
   }

--- a/ui/app/com/gu/recipeasy/controllers/Admin.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Admin.scala
@@ -16,6 +16,8 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import auth.Authorisation
 
+import play.api.libs.json._
+
 class Admin(override val wsClient: WSClient, override val conf: Configuration, db: DB, val messagesApi: MessagesApi, googleGroupAuthorizer: Authorisation) extends Controller with AuthActions with I18nSupport with StrictLogging {
 
   type AuthReq[A] = AuthenticatedRequest[A, UserIdentity]
@@ -81,6 +83,15 @@ class Admin(override val wsClient: WSClient, override val conf: Configuration, d
       RecipeStatusImpossible -> db.countRecipesInGivenStatus(RecipeStatusImpossible)
     )
     Ok(views.html.admin.statusdistribution(distribution))
+  }
+
+  def idsLookupPage = AdminAuth { implicit request =>
+    Ok(views.html.admin.idslookup())
+  }
+
+  def idsLookupAsync(articleId: String) = AdminAuth { implicit request =>
+    val recipeIds = db.getOriginalRecipesByArticleId(articleId).map(_.id)
+    Ok(Json.toJson(recipeIds));
   }
 
 }

--- a/ui/app/com/gu/recipeasy/controllers/Admin.scala
+++ b/ui/app/com/gu/recipeasy/controllers/Admin.scala
@@ -89,7 +89,7 @@ class Admin(override val wsClient: WSClient, override val conf: Configuration, d
     Ok(views.html.admin.idslookup())
   }
 
-  def idsLookupAsync(articleId: String) = AdminAuth { implicit request =>
+  def articleIdToRecipesIds(articleId: String) = AdminAuth { implicit request =>
     val recipeIds = db.getOriginalRecipesByArticleId(articleId).map(_.id)
     Ok(Json.toJson(recipeIds));
   }

--- a/ui/app/com/gu/recipeasy/views/admin/idslookup.scala.html
+++ b/ui/app/com/gu/recipeasy/views/admin/idslookup.scala.html
@@ -7,15 +7,14 @@
     <script>
             $(document).delegate('#form-button', 'click', function(e){
                 const articleId = $("#form-text").val();
-                console.log(articleId)
                 $.ajax({
                     type: "GET",
-                    url: '/admin/idslookup-async/'+encodeURIComponent(articleId),
+                    url: '/admin/articleid-to-recipeids/'+encodeURIComponent(articleId),
                     data: null,
                     success: function(recipeIds){
                         $("#result-display-area").empty();
                         recipeIds.forEach(function(recipeId){
-                            $("#result-display-area").append('<div><a href="/recipe/verify/'+recipeId+'" target="_blank">Recipe: '+recipeId+'</div>');
+                            $("#result-display-area").append('<div><a href="/recipe/curate/'+recipeId+'" target="_blank" rel="noopener noreferrer">Recipe: '+recipeId+'</div>');
                         },recipeIds);
                     },
                     error: function(){

--- a/ui/app/com/gu/recipeasy/views/admin/idslookup.scala.html
+++ b/ui/app/com/gu/recipeasy/views/admin/idslookup.scala.html
@@ -1,0 +1,45 @@
+@import com.gu.recipeasy.views
+@()(implicit messages: play.api.i18n.Messages, request: RequestHeader)
+@layout("IDs Lookup") {
+
+    @views.html.admin.partials.navigation()
+
+    <script>
+            $(document).delegate('#form-button', 'click', function(e){
+                const articleId = $("#form-text").val();
+                console.log(articleId)
+                $.ajax({
+                    type: "GET",
+                    url: '/admin/idslookup-async/'+encodeURIComponent(articleId),
+                    data: null,
+                    success: function(recipeIds){
+                        $("#result-display-area").empty();
+                        recipeIds.forEach(function(recipeId){
+                            $("#result-display-area").append('<div><a href="/recipe/verify/'+recipeId+'" target="_blank">Recipe: '+recipeId+'</div>');
+                        },recipeIds);
+                    },
+                    error: function(){
+
+                    }
+                });
+            });
+    </script>
+
+    <div style="padding:20px;">
+
+        <div>Enter an article Id and then press "Lookup" to retrieve a link to the recipes Ids of that article.</div>
+
+        <div style="margin-top:20px;">
+            <form method="POST">
+                <input id="form-text" type="text" style="width:80%" /><br />
+                <input id="form-button" style="margin-top:10px;" value="Lookup" type="button">
+            </form>
+        </div>
+
+        <div id="result-display-area" style="margin-top:20px;">
+
+        </div>
+
+    </div>
+
+}

--- a/ui/app/com/gu/recipeasy/views/admin/index.scala.html
+++ b/ui/app/com/gu/recipeasy/views/admin/index.scala.html
@@ -7,6 +7,7 @@
         <li><a href="@routes.Admin.dailyBreakdown">Daily Breakdown</li>
         <li><a href="@routes.Admin.leaderboard">Leaderboard</li>
         <li><a href="@routes.Admin.usersListing">Users emails</li>
+        <li><a href="@routes.Admin.idsLookupPage">IDs Lookup</li>
         <li><a href="@routes.Application.verifyOneRecipe">Perform One Verification</li>
     </ul>
 }

--- a/ui/conf/routes
+++ b/ui/conf/routes
@@ -29,6 +29,8 @@ GET        /admin/status-distribution                                     contro
 GET        /admin/users                                                   controllers.Admin.usersListing
 GET        /admin/daily-breakdown                                         controllers.Admin.dailyBreakdown
 GET        /admin/leaderboard                                             controllers.Admin.leaderboard
+GET        /admin/idslookup                                               controllers.Admin.idsLookupPage
+GET        /admin/idslookup-async/:articleId                              controllers.Admin.idsLookupAsync(articleId)
 
 POST       /admin/prepare-recipes                                         controllers.Application.prepareRecipesForCuration
 

--- a/ui/conf/routes
+++ b/ui/conf/routes
@@ -30,7 +30,7 @@ GET        /admin/users                                                   contro
 GET        /admin/daily-breakdown                                         controllers.Admin.dailyBreakdown
 GET        /admin/leaderboard                                             controllers.Admin.leaderboard
 GET        /admin/idslookup                                               controllers.Admin.idsLookupPage
-GET        /admin/idslookup-async/:articleId                              controllers.Admin.idsLookupAsync(articleId)
+GET        /admin/articleid-to-recipeids/:articleId                       controllers.Admin.articleIdToRecipesIds(articleId)
 
 POST       /admin/prepare-recipes                                         controllers.Application.prepareRecipesForCuration
 


### PR DESCRIPTION
This change enables admin users ( eg: Chris ) to access the recipeasy curation pages of recipes given the article ID (which is sometimes the only piece of information that business users wanting to correct a recipe have access to).